### PR TITLE
Makes (almost) all links to us2ts.org relative

### DIFF
--- a/2018/index.html
+++ b/2018/index.html
@@ -19,11 +19,11 @@
   
     <link href="http://us2ts.org/2018/index.xml" rel="alternate" type="application/rss+xml" title="U.S. Semantic Technologies Symposium 2018" />
     <link href="http://us2ts.org/2018/index.xml" rel="feed" type="application/rss+xml" title="U.S. Semantic Technologies Symposium 2018" />
-  <link rel='icon' href='http://us2ts.org/2019/favicon.ico'>
+  <link rel='icon' href='/2019/favicon.ico'>
 <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-<link rel='stylesheet' href='http://us2ts.org/2019/css/main.67a788c9.css'>
+<link rel='stylesheet' href='/2019/css/main.67a788c9.css'>
 
-  <link rel='stylesheet' href='http://us2ts.org/2019/css/custom.css'>
+  <link rel='stylesheet' href='/2019/css/custom.css'>
 
 
 
@@ -33,13 +33,13 @@
 <body class='home'>
   <div class='site'>
     <header id='header' class='header-container'>
-	<div><a href="http://us2ts.org"><img src="http://us2ts.org/2018/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a> U.S. Semantic Technologies Symposium Series <br/> <div style="font-size: 70%;"> March 1-2, 2018, at Wright State University, Dayton, Ohio</div></div><hr>
+	<div><a href="/"><img src="/2018/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a> U.S. Semantic Technologies Symposium Series <br/> <div style="font-size: 70%;"> March 1-2, 2018, at Wright State University, Dayton, Ohio</div></div><hr>
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
   <ul class='main-menu'>
     
     <li>
-      <a href='http://us2ts.org/2018/' 
+      <a href='/2018/' 
         
            class='current' aria-current='page'
         
@@ -47,31 +47,31 @@
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/program/' 
+      <a href='/2018/posts/program/' 
         
       >Program</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/registration/' 
+      <a href='/2018/posts/registration/' 
         
       >Register</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/travel/' 
+      <a href='/2018/posts/travel/' 
         
       >Accomodation</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/venue/' 
+      <a href='/2018/posts/venue/' 
         
       >Venue</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/sponsors/' 
+      <a href='/2018/posts/sponsors/' 
         
       >Sponsors</a>
     </li>
@@ -94,8 +94,8 @@
   <article class='entry'>
     <div class='entry-content'>
 
-	<p><strong>News:</strong> US2TS 2019 site is live:	<a href='http://us2ts.org/2019'> US2TS 2019</a></p>
-  <p><strong>News:</strong> Pictures from the event are available <a href="http://us2ts.org/2018/us2ts2018.zip">here</a>.</p>
+	<p><strong>News:</strong> US2TS 2019 site is live:	<a href='/2019'> US2TS 2019</a></p>
+  <p><strong>News:</strong> Pictures from the event are available <a href="/2018/us2ts2018.zip">here</a>.</p>
 
 <p><strong>News:</strong> We have reached the capacity limit for the event at 120 people. Please contact Pascal Hitzler (pascal.hitzler@wright.edu) to get put on a waiting list.</p>
 
@@ -161,40 +161,40 @@
 <li>Chris Mungall, Lawrence Berkeley National Laboratory</li>
 </ul>
 
-<p>You can find a flyer for the event <a href="http://us2ts.org/2018/EventFlyer-us2ts2018.pdf">here</a>.</p>
+<p>You can find a flyer for the event <a href="/2018/EventFlyer-us2ts2018.pdf">here</a>.</p>
 
-<p>Students can apply for an NSF-supported <a href="http://us2ts.org/2018/announcement.pdf">Student Travel Grant</a>.</p>
+<p>Students can apply for an NSF-supported <a href="/2018/announcement.pdf">Student Travel Grant</a>.</p>
 
 <p>The following sponsors have expressed their financial support for US2TS 2018.</p>
 
 <ul>
-<li><p><a href="https://www.iospress.nl/subject/semantic-web/"> <img src="http://us2ts.org/2018/IOS_Logo_black_RGB.jpg" width="300px"></a>.</p></li>
+<li><p><a href="https://www.iospress.nl/subject/semantic-web/"> <img src="/2018/IOS_Logo_black_RGB.jpg" width="300px"></a>.</p></li>
 
-<li><p><a href="http://geglobalresearch.com/"> <img src="http://us2ts.org/2018/ge_logo.png" width="300px"></a>.</p></li>
+<li><p><a href="http://geglobalresearch.com/"> <img src="/2018/ge_logo.png" width="300px"></a>.</p></li>
 
-<li><p><a href="https://nsf.gov/"> <img src="http://us2ts.org/2018/nsf4.jpg" width="300px"></a>.</p></li>
+<li><p><a href="https://nsf.gov/"> <img src="/2018/nsf4.jpg" width="300px"></a>.</p></li>
 
-<li><p><a href="https://www.oclc.org"> <img src="http://us2ts.org/2018/OCLC_Logo_H_Color_NoTag_JPG.jpg" width="300px"></a>.</p></li>
+<li><p><a href="https://www.oclc.org"> <img src="/2018/OCLC_Logo_H_Color_NoTag_JPG.jpg" width="300px"></a>.</p></li>
 
-<li><p><a href="https://www.thomsonreuters.com/en.html"> <img src="http://us2ts.org/2018/tr.png" width="300px"></a>.</p></li>
+<li><p><a href="https://www.thomsonreuters.com/en.html"> <img src="/2018/tr.png" width="300px"></a>.</p></li>
 
-<li><p><a href="https://tenet3.com/"> <img src="http://us2ts.org/2018/Tenet3_black.png" width="300px"></a>.</p></li>
+<li><p><a href="https://tenet3.com/"> <img src="/2018/Tenet3_black.png" width="300px"></a>.</p></li>
 
-<li><p><a href="https://jobs.raytheon.com/job/rosslyn/staff-scientist-ii-information-exploitation/4679/6118427"> <img src="http://us2ts.org/2018/logo-bbn.png"  width="300px"></a>.</p></li>
+<li><p><a href="https://jobs.raytheon.com/job/rosslyn/staff-scientist-ii-information-exploitation/4679/6118427"> <img src="/2018/logo-bbn.png"  width="300px"></a>.</p></li>
 
-<li><p><a href="https://www.bosch.us/"> <img src="http://us2ts.org/2018/Bosch_Logo.jpg"  width="300px"></a>.</p></li>
+<li><p><a href="https://www.bosch.us/"> <img src="/2018/Bosch_Logo.jpg"  width="300px"></a>.</p></li>
 
-<li><p><a href="https://franz.com/"> <img src="http://us2ts.org/2018/AllegroGraph-Franz Logo.png"  width="300px"></a>.</p></li>
+<li><p><a href="https://franz.com/"> <img src="/2018/AllegroGraph-Franz Logo.png"  width="300px"></a>.</p></li>
 
-<li><p><a href="http://bit.ly/CRCSTS18"> <img src="http://us2ts.org/2018/CRC.jpg"  width="300px"></a>.</p></li>
+<li><p><a href="http://bit.ly/CRCSTS18"> <img src="/2018/CRC.jpg"  width="300px"></a>.</p></li>
 
-<li><p><a href="https://sloan.org/"> <img src="http://us2ts.org/2018/sloan.png"  width="300px"></a>.</p></li>
+<li><p><a href="https://sloan.org/"> <img src="/2018/sloan.png"  width="300px"></a>.</p></li>
 
 <li><p><a href="https://www.google.com/"> Google</a>.</p></li>
 
-<li><p><a href="http://dssc.cs.wright.edu/"> <img src="http://us2ts.org/2018/dssc-logo-transparent.png" width="300px"></a>.</p></li>
+<li><p><a href="http://dssc.cs.wright.edu/"> <img src="/2018/dssc-logo-transparent.png" width="300px"></a>.</p></li>
 
-<li><p><a href="https://engineering-computer-science.wright.edu/computer-science-and-engineering"> <img src="http://us2ts.org/2018/DeptLogo_CSE.png" width="300px"></a>.</p></li>
+<li><p><a href="https://engineering-computer-science.wright.edu/computer-science-and-engineering"> <img src="/2018/DeptLogo_CSE.png" width="300px"></a>.</p></li>
 </ul>
 
 <p>For all questions please contact Pascal Hitzler at pascal.hitzler@wright.edu</p>
@@ -216,7 +216,7 @@
   </div>
   <header class='list-item-header'>
     <h3 class='list-item-title'>
-      <a href='http://us2ts.org/2018/posts/registration/'>Registration</a>
+      <a href='/2018/posts/registration/'>Registration</a>
     </h3>
   </header>
 </article>
@@ -231,7 +231,7 @@
   </div>
   <header class='list-item-header'>
     <h3 class='list-item-title'>
-      <a href='http://us2ts.org/2018/posts/sponsors/'>Sponsors</a>
+      <a href='/2018/posts/sponsors/'>Sponsors</a>
     </h3>
   </header>
 </article>
@@ -246,7 +246,7 @@
   </div>
   <header class='list-item-header'>
     <h3 class='list-item-title'>
-      <a href='http://us2ts.org/2018/posts/contributions/'>Contributions</a>
+      <a href='/2018/posts/contributions/'>Contributions</a>
     </h3>
   </header>
 </article>
@@ -261,7 +261,7 @@
   </div>
   <header class='list-item-header'>
     <h3 class='list-item-title'>
-      <a href='http://us2ts.org/2018/posts/venue/'>Venue</a>
+      <a href='/2018/posts/venue/'>Venue</a>
     </h3>
   </header>
 </article>
@@ -276,7 +276,7 @@
   </div>
   <header class='list-item-header'>
     <h3 class='list-item-title'>
-      <a href='http://us2ts.org/2018/posts/program/'>Program</a>
+      <a href='/2018/posts/program/'>Program</a>
     </h3>
   </header>
 </article>
@@ -300,9 +300,9 @@
 
   </div>
 
-  <script src="http://us2ts.org/2018//main.af838dd5.js'></script>
+  <script src="/2018//main.af838dd5.js'></script>
   
-    <script src="http://us2ts.org/2018//custom.js'></script>
+    <script src="/2018//custom.js'></script>
   
 
 </body>

--- a/2018/posts/contributions/index.html
+++ b/2018/posts/contributions/index.html
@@ -16,11 +16,11 @@
 
   <title>Contributions • U.S. Semantic Technologies Symposium 2018</title>
   <link rel='canonical' href='http://us2ts.org/2018/posts/contributions/'>
-  <link rel='icon' href='http://us2ts.org/2018/favicon.ico'>
+  <link rel='icon' href='/2018/favicon.ico'>
 <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-<link rel='stylesheet' href='http://us2ts.org/2018/css/main.67a788c9.css'>
+<link rel='stylesheet' href='/2018/css/main.67a788c9.css'>
 
-  <link rel='stylesheet' href='http://us2ts.org/2018/css/custom.css'>
+  <link rel='stylesheet' href='/2018/css/custom.css'>
 
 
 
@@ -30,43 +30,43 @@
 <body class='page'>
   <div class='site'>
     <header id='header' class='header-container'>
-	<div><a href="http://us2ts.org"><img src="http://us2ts.org/2018/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a> U.S. Semantic Technologies Symposium Series <br/> <div style="font-size: 70%;"> March 1-2, 2018, at Wright State University, Dayton, Ohio</div></div><hr>
+	<div><a href="/"><img src="/2018/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a> U.S. Semantic Technologies Symposium Series <br/> <div style="font-size: 70%;"> March 1-2, 2018, at Wright State University, Dayton, Ohio</div></div><hr>
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
   <ul class='main-menu'>
     
     <li>
-      <a href='http://us2ts.org/2018/' 
+      <a href='/2018/' 
         
       >About</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/program/' 
+      <a href='/2018/posts/program/' 
         
       >Program</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/registration/' 
+      <a href='/2018/posts/registration/' 
         
       >Register</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/travel/' 
+      <a href='/2018/posts/travel/' 
         
       >Accomodation</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/venue/' 
+      <a href='/2018/posts/venue/' 
         
       >Venue</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/sponsors/' 
+      <a href='/2018/posts/sponsors/' 
         
       >Sponsors</a>
     </li>
@@ -134,7 +134,7 @@
     
 <nav class='entry-nav'>
   <div class='entry-nav-links'><div class='prev-entry'>
-      <a href='http://us2ts.org/2018/posts/venue/'>
+      <a href='/2018/posts/venue/'>
         <span aria-hidden='true'><svg class='icon' viewbox='0 0 24 24' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' aria-hidden='true'>
   
   <line x1="20" y1="12" x2="4" y2="12"/>
@@ -144,7 +144,7 @@
  Previous</span>
         <span class='screen-reader'>Previous post: </span>Venue</a>
     </div><div class='next-entry'>
-      <a href='http://us2ts.org/2018/posts/sponsors/'>
+      <a href='/2018/posts/sponsors/'>
         <span class='screen-reader'>Next post: </span>Sponsors<span aria-hidden='true'>Next <svg class='icon' viewbox='0 0 24 24' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' aria-hidden='true'>
   
   <line x1="4" y1="12" x2="20" y2="12"/>
@@ -181,9 +181,9 @@
 
   </div>
 
-  <script src='http://us2ts.org/2018//main.af838dd5.js'></script>
+  <script src='/2018//main.af838dd5.js'></script>
   
-    <script src='http://us2ts.org/2018//custom.js'></script>
+    <script src='/2018//custom.js'></script>
   
 
 </body>

--- a/2018/posts/program/index.html
+++ b/2018/posts/program/index.html
@@ -18,11 +18,11 @@ The registration desk will be open from 8:00am on March 1, and will be located i
 
   <title>Program • U.S. Semantic Technologies Symposium 2018</title>
   <link rel='canonical' href='http://us2ts.org/2018/posts/program/'>
-  <link rel='icon' href='http://us2ts.org/2018/favicon.ico'>
+  <link rel='icon' href='/2018/favicon.ico'>
 <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-<link rel='stylesheet' href='http://us2ts.org/2018/css/main.67a788c9.css'>
+<link rel='stylesheet' href='/2018/css/main.67a788c9.css'>
 
-  <link rel='stylesheet' href='http://us2ts.org/2018/css/custom.css'>
+  <link rel='stylesheet' href='/2018/css/custom.css'>
 
 
 
@@ -32,43 +32,43 @@ The registration desk will be open from 8:00am on March 1, and will be located i
 <body class='page'>
   <div class='site'>
     <header id='header' class='header-container'>
-	<div><a href="http://us2ts.org"><img src="http://us2ts.org/2018/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a> U.S. Semantic Technologies Symposium Series <br/> <div style="font-size: 70%;"> March 1-2, 2018, at Wright State University, Dayton, Ohio</div></div><hr>
+	<div><a href="/"><img src="/2018/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a> U.S. Semantic Technologies Symposium Series <br/> <div style="font-size: 70%;"> March 1-2, 2018, at Wright State University, Dayton, Ohio</div></div><hr>
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
   <ul class='main-menu'>
     
     <li>
-      <a href='http://us2ts.org/2018/' 
+      <a href='/2018/' 
         
       >About</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/program/' 
+      <a href='/2018/posts/program/' 
         
       >Program</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/registration/' 
+      <a href='/2018/posts/registration/' 
         
       >Register</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/travel/' 
+      <a href='/2018/posts/travel/' 
         
       >Accomodation</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/venue/' 
+      <a href='/2018/posts/venue/' 
         
       >Venue</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/sponsors/' 
+      <a href='/2018/posts/sponsors/' 
         
       >Sponsors</a>
     </li>
@@ -324,7 +324,7 @@ Over the last few years we have been building domain-specific knowledge graphs f
     
 <nav class='entry-nav'>
   <div class='entry-nav-links'><div class='prev-entry'>
-      <a href='http://us2ts.org/2018/posts/travel/'>
+      <a href='/2018/posts/travel/'>
         <span aria-hidden='true'><svg class='icon' viewbox='0 0 24 24' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' aria-hidden='true'>
   
   <line x1="20" y1="12" x2="4" y2="12"/>
@@ -334,7 +334,7 @@ Over the last few years we have been building domain-specific knowledge graphs f
  Previous</span>
         <span class='screen-reader'>Previous post: </span>Hotel</a>
     </div><div class='next-entry'>
-      <a href='http://us2ts.org/2018/posts/venue/'>
+      <a href='/2018/posts/venue/'>
         <span class='screen-reader'>Next post: </span>Venue<span aria-hidden='true'>Next <svg class='icon' viewbox='0 0 24 24' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' aria-hidden='true'>
   
   <line x1="4" y1="12" x2="20" y2="12"/>
@@ -371,9 +371,9 @@ Over the last few years we have been building domain-specific knowledge graphs f
 
   </div>
 
-  <script src='http://us2ts.org/2018//main.af838dd5.js'></script>
+  <script src='/2018//main.af838dd5.js'></script>
   
-    <script src='http://us2ts.org/2018//custom.js'></script>
+    <script src='/2018//custom.js'></script>
   
 
 </body>

--- a/2018/posts/registration/index.html
+++ b/2018/posts/registration/index.html
@@ -18,11 +18,11 @@ Please use our registration site (closed) to register for the symposium. Registr
 
   <title>Registration • U.S. Semantic Technologies Symposium 2018</title>
   <link rel='canonical' href='http://us2ts.org/2018/posts/registration/'>
-  <link rel='icon' href='http://us2ts.org/2018/favicon.ico'>
+  <link rel='icon' href='/2018/favicon.ico'>
 <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-<link rel='stylesheet' href='http://us2ts.org/2018/css/main.67a788c9.css'>
+<link rel='stylesheet' href='/2018/css/main.67a788c9.css'>
 
-  <link rel='stylesheet' href='http://us2ts.org/2018/css/custom.css'>
+  <link rel='stylesheet' href='/2018/css/custom.css'>
 
 
 
@@ -32,43 +32,43 @@ Please use our registration site (closed) to register for the symposium. Registr
 <body class='page'>
   <div class='site'>
     <header id='header' class='header-container'>
-	<div><a href="http://us2ts.org"><img src="http://us2ts.org/2018/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a> U.S. Semantic Technologies Symposium Series <br/> <div style="font-size: 70%;"> March 1-2, 2018, at Wright State University, Dayton, Ohio</div></div><hr>
+	<div><a href="/"><img src="/2018/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a> U.S. Semantic Technologies Symposium Series <br/> <div style="font-size: 70%;"> March 1-2, 2018, at Wright State University, Dayton, Ohio</div></div><hr>
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
   <ul class='main-menu'>
     
     <li>
-      <a href='http://us2ts.org/2018/' 
+      <a href='/2018/' 
         
       >About</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/program/' 
+      <a href='/2018/posts/program/' 
         
       >Program</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/registration/' 
+      <a href='/2018/posts/registration/' 
         
       >Register</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/travel/' 
+      <a href='/2018/posts/travel/' 
         
       >Accomodation</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/venue/' 
+      <a href='/2018/posts/venue/' 
         
       >Venue</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/sponsors/' 
+      <a href='/2018/posts/sponsors/' 
         
       >Sponsors</a>
     </li>
@@ -118,13 +118,13 @@ Please use our registration site (closed) to register for the symposium. Registr
     <div class='entry-content'>
   <p><strong>News:</strong> We have reached the capacity limit for the event at 120 people. Please contact Pascal Hitzler (pascal.hitzler@wright.edu) to get put on a waiting list.</p>
 
-<p>Please use our <a href="http://us2ts.org/2018/posts/registration/"><em>registration site (closed)</em></a> to register for the symposium. Registration includes lunches as well as coffee breaks with snacks. Until January 15, 2018 (early registration deadline), registration costs $150 for a regular attendee, and $75 for a student attendee. Registration cost doubles on January 16, 2018. Due to space limitations, attendance will be capped at 120, we recommend that you register early. Please note that registration will close February 15; contact Pascal Hitzler (pascal.hitzler@wright.edu) directly to register past this deadline.</p>
+<p>Please use our <a href="/2018/posts/registration/"><em>registration site (closed)</em></a> to register for the symposium. Registration includes lunches as well as coffee breaks with snacks. Until January 15, 2018 (early registration deadline), registration costs $150 for a regular attendee, and $75 for a student attendee. Registration cost doubles on January 16, 2018. Due to space limitations, attendance will be capped at 120, we recommend that you register early. Please note that registration will close February 15; contact Pascal Hitzler (pascal.hitzler@wright.edu) directly to register past this deadline.</p>
 
-<p>Students can apply for an NSF-supported <a href="http://us2ts.org/2018/announcement.pdf">Student Travel Grant</a>.</p>
+<p>Students can apply for an NSF-supported <a href="/2018/announcement.pdf">Student Travel Grant</a>.</p>
 
 <p>As a symposium, the focus of US2TS will be on discussions and community building, and thus there is no paper track. However, everybody is invited and encouraged to bring an A1-sized poster to the poster reception. Please indicate during the registration whether you plan on bringing a poster as space is limited.</p>
 
-<p>In order to book a hotel, please see our <a href="http://us2ts.org/2018/posts/travel/"><em>accommodation page</em></a>.</p>
+<p>In order to book a hotel, please see our <a href="/2018/posts/travel/"><em>accommodation page</em></a>.</p>
 
 <p>We have a limited number of student travel grants available thanks to sponsoring by the National Science Foundation. Information about this will be available shortly.</p>
 
@@ -146,7 +146,7 @@ Please use our registration site (closed) to register for the symposium. Registr
     
 <nav class='entry-nav'>
   <div class='entry-nav-links'><div class='prev-entry'>
-      <a href='http://us2ts.org/2018/posts/sponsors/'>
+      <a href='/2018/posts/sponsors/'>
         <span aria-hidden='true'><svg class='icon' viewbox='0 0 24 24' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' aria-hidden='true'>
   
   <line x1="20" y1="12" x2="4" y2="12"/>
@@ -183,9 +183,9 @@ Please use our registration site (closed) to register for the symposium. Registr
 
   </div>
 
-  <script src='http://us2ts.org/2018//main.af838dd5.js'></script>
+  <script src='/2018//main.af838dd5.js'></script>
   
-    <script src='http://us2ts.org/2018//custom.js'></script>
+    <script src='/2018//custom.js'></script>
   
 
 </body>

--- a/2018/posts/sponsors/index.html
+++ b/2018/posts/sponsors/index.html
@@ -46,11 +46,11 @@
 
   <title>Sponsors • U.S. Semantic Technologies Symposium 2018</title>
   <link rel='canonical' href='http://us2ts.org/2018/posts/sponsors/'>
-  <link rel='icon' href='http://us2ts.org/2018/favicon.ico'>
+  <link rel='icon' href='/2018/favicon.ico'>
 <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-<link rel='stylesheet' href='http://us2ts.org/2018/css/main.67a788c9.css'>
+<link rel='stylesheet' href='/2018/css/main.67a788c9.css'>
 
-  <link rel='stylesheet' href='http://us2ts.org/2018/css/custom.css'>
+  <link rel='stylesheet' href='/2018/css/custom.css'>
 
 
 
@@ -60,43 +60,43 @@
 <body class='page'>
   <div class='site'>
     <header id='header' class='header-container'>
-	<div><a href="http://us2ts.org"><img src="http://us2ts.org/2018/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a> U.S. Semantic Technologies Symposium Series <br/> <div style="font-size: 70%;"> March 1-2, 2018, at Wright State University, Dayton, Ohio</div></div><hr>
+	<div><a href="/"><img src="/2018/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a> U.S. Semantic Technologies Symposium Series <br/> <div style="font-size: 70%;"> March 1-2, 2018, at Wright State University, Dayton, Ohio</div></div><hr>
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
   <ul class='main-menu'>
     
     <li>
-      <a href='http://us2ts.org/2018/' 
+      <a href='/2018/' 
         
       >About</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/program/' 
+      <a href='/2018/posts/program/' 
         
       >Program</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/registration/' 
+      <a href='/2018/posts/registration/' 
         
       >Register</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/travel/' 
+      <a href='/2018/posts/travel/' 
         
       >Accomodation</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/venue/' 
+      <a href='/2018/posts/venue/' 
         
       >Venue</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/sponsors/' 
+      <a href='/2018/posts/sponsors/' 
         
       >Sponsors</a>
     </li>
@@ -147,33 +147,33 @@
   <p>The following sponsors have expressed their financial support for US2TS 2018.</p>
 
 <ul>
-<li><p><a href="https://www.iospress.nl/subject/semantic-web/"> <img src="http://us2ts.org/2018/IOS_Logo_black_RGB.jpg" width="300px"></a>.</p></li>
+<li><p><a href="https://www.iospress.nl/subject/semantic-web/"> <img src="/2018/IOS_Logo_black_RGB.jpg" width="300px"></a>.</p></li>
 
-<li><p><a href="http://geglobalresearch.com/"> <img src="http://us2ts.org/2018/ge_logo.png" width="300px"></a>.</p></li>
+<li><p><a href="http://geglobalresearch.com/"> <img src="/2018/ge_logo.png" width="300px"></a>.</p></li>
 
-<li><p><a href="https://nsf.gov/"> <img src="http://us2ts.org/2018/nsf4.jpg" width="300px"></a>.</p></li>
+<li><p><a href="https://nsf.gov/"> <img src="/2018/nsf4.jpg" width="300px"></a>.</p></li>
 
-<li><p><a href="https://www.oclc.org"> <img src="http://us2ts.org/2018/OCLC_Logo_H_Color_NoTag_JPG.jpg" width="300px"></a>.</p></li>
+<li><p><a href="https://www.oclc.org"> <img src="/2018/OCLC_Logo_H_Color_NoTag_JPG.jpg" width="300px"></a>.</p></li>
 
-<li><p><a href="https://www.thomsonreuters.com/en.html"> <img src="http://us2ts.org/2018/tr.png" width="300px"></a>.</p></li>
+<li><p><a href="https://www.thomsonreuters.com/en.html"> <img src="/2018/tr.png" width="300px"></a>.</p></li>
 
-<li><p><a href="https://tenet3.com/"> <img src="http://us2ts.org/2018/Tenet3_black.png" width="300px"></a>.</p></li>
+<li><p><a href="https://tenet3.com/"> <img src="/2018/Tenet3_black.png" width="300px"></a>.</p></li>
 
-<li><p><a href="https://jobs.raytheon.com/job/rosslyn/staff-scientist-ii-information-exploitation/4679/6118427"> <img src="http://us2ts.org/2018/logo-bbn.png"  width="300px"></a>.</p></li>
+<li><p><a href="https://jobs.raytheon.com/job/rosslyn/staff-scientist-ii-information-exploitation/4679/6118427"> <img src="/2018/logo-bbn.png"  width="300px"></a>.</p></li>
 
-<li><p><a href="https://www.bosch.us/"> <img src="http://us2ts.org/2018/Bosch_Logo.jpg"  width="300px"></a>.</p></li>
+<li><p><a href="https://www.bosch.us/"> <img src="/2018/Bosch_Logo.jpg"  width="300px"></a>.</p></li>
 
-<li><p><a href="https://franz.com/"> <img src="http://us2ts.org/2018/AllegroGraph-Franz Logo.png"  width="300px"></a>.</p></li>
+<li><p><a href="https://franz.com/"> <img src="/2018/AllegroGraph-Franz Logo.png"  width="300px"></a>.</p></li>
 
-<li><p><a href="http://bit.ly/CRCSTS18"> <img src="http://us2ts.org/2018/CRC.jpg"  width="300px"></a>.</p></li>
+<li><p><a href="http://bit.ly/CRCSTS18"> <img src="/2018/CRC.jpg"  width="300px"></a>.</p></li>
 
-<li><p><a href="https://sloan.org/"> <img src="http://us2ts.org/2018/sloan.png"  width="300px"></a>.</p></li>
+<li><p><a href="https://sloan.org/"> <img src="/2018/sloan.png"  width="300px"></a>.</p></li>
 
 <li><p><a href="https://www.google.com/"> Google</a>.</p></li>
 
-<li><p><a href="http://dssc.cs.wright.edu/"> <img src="http://us2ts.org/2018/dssc-logo-transparent.png" width="300px"></a>.</p></li>
+<li><p><a href="http://dssc.cs.wright.edu/"> <img src="/2018/dssc-logo-transparent.png" width="300px"></a>.</p></li>
 
-<li><p><a href="https://engineering-computer-science.wright.edu/computer-science-and-engineering"> <img src="http://us2ts.org/2018/DeptLogo_CSE.png" width="300px"></a>.</p></li>
+<li><p><a href="https://engineering-computer-science.wright.edu/computer-science-and-engineering"> <img src="/2018/DeptLogo_CSE.png" width="300px"></a>.</p></li>
 </ul>
 
 </div>
@@ -194,7 +194,7 @@
     
 <nav class='entry-nav'>
   <div class='entry-nav-links'><div class='prev-entry'>
-      <a href='http://us2ts.org/2018/posts/contributions/'>
+      <a href='/2018/posts/contributions/'>
         <span aria-hidden='true'><svg class='icon' viewbox='0 0 24 24' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' aria-hidden='true'>
   
   <line x1="20" y1="12" x2="4" y2="12"/>
@@ -204,7 +204,7 @@
  Previous</span>
         <span class='screen-reader'>Previous post: </span>Contributions</a>
     </div><div class='next-entry'>
-      <a href='http://us2ts.org/2018/posts/registration/'>
+      <a href='/2018/posts/registration/'>
         <span class='screen-reader'>Next post: </span>Registration<span aria-hidden='true'>Next <svg class='icon' viewbox='0 0 24 24' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' aria-hidden='true'>
   
   <line x1="4" y1="12" x2="20" y2="12"/>
@@ -241,9 +241,9 @@
 
   </div>
 
-  <script src="http://us2ts.org/2018//main.af838dd5.js'></script>
+  <script src="/2018//main.af838dd5.js'></script>
   
-    <script src="http://us2ts.org/2018//custom.js'></script>
+    <script src="/2018//custom.js'></script>
   
 
 </body>

--- a/2018/posts/travel/index.html
+++ b/2018/posts/travel/index.html
@@ -30,11 +30,11 @@ Distance to Venue: 1.1 mile'>
 
   <title>Hotel • U.S. Semantic Technologies Symposium 2018</title>
   <link rel='canonical' href='http://us2ts.org/2018/posts/travel/'>
-  <link rel='icon' href='http://us2ts.org/2018/favicon.ico'>
+  <link rel='icon' href='/2018/favicon.ico'>
 <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-<link rel='stylesheet' href='http://us2ts.org/2018/css/main.67a788c9.css'>
+<link rel='stylesheet' href='/2018/css/main.67a788c9.css'>
 
-  <link rel='stylesheet' href='http://us2ts.org/2018/css/custom.css'>
+  <link rel='stylesheet' href='/2018/css/custom.css'>
 
 
 
@@ -44,43 +44,43 @@ Distance to Venue: 1.1 mile'>
 <body class='page'>
   <div class='site'>
     <header id='header' class='header-container'>
-	<div><a href="http://us2ts.org"><img src="http://us2ts.org/2018/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a> U.S. Semantic Technologies Symposium Series <br/> <div style="font-size: 70%;"> March 1-2, 2018, at Wright State University, Dayton, Ohio</div></div><hr>
+	<div><a href="/"><img src="/2018/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a> U.S. Semantic Technologies Symposium Series <br/> <div style="font-size: 70%;"> March 1-2, 2018, at Wright State University, Dayton, Ohio</div></div><hr>
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
   <ul class='main-menu'>
     
     <li>
-      <a href='http://us2ts.org/2018/' 
+      <a href='/2018/' 
         
       >About</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/program/' 
+      <a href='/2018/posts/program/' 
         
       >Program</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/registration/' 
+      <a href='/2018/posts/registration/' 
         
       >Register</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/travel/' 
+      <a href='/2018/posts/travel/' 
         
       >Accomodation</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/venue/' 
+      <a href='/2018/posts/venue/' 
         
       >Venue</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/sponsors/' 
+      <a href='/2018/posts/sponsors/' 
         
       >Sponsors</a>
     </li>
@@ -199,7 +199,7 @@ Distance to Venue: 1.1 mile'>
     
 <nav class='entry-nav'>
   <div class='entry-nav-links'><div class='next-entry'>
-      <a href='http://us2ts.org/2018/posts/program/'>
+      <a href='/2018/posts/program/'>
         <span class='screen-reader'>Next post: </span>Program<span aria-hidden='true'>Next <svg class='icon' viewbox='0 0 24 24' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' aria-hidden='true'>
   
   <line x1="4" y1="12" x2="20" y2="12"/>
@@ -236,9 +236,9 @@ Distance to Venue: 1.1 mile'>
 
   </div>
 
-  <script src='http://us2ts.org/2018//main.af838dd5.js'></script>
+  <script src='/2018//main.af838dd5.js'></script>
   
-    <script src='http://us2ts.org/2018//custom.js'></script>
+    <script src='/2018//custom.js'></script>
   
 
 </body>

--- a/2018/posts/venue/index.html
+++ b/2018/posts/venue/index.html
@@ -16,11 +16,11 @@
 
   <title>Venue • U.S. Semantic Technologies Symposium 2018</title>
   <link rel='canonical' href='http://us2ts.org/2018/posts/venue/'>
-  <link rel='icon' href='http://us2ts.org/2018/favicon.ico'>
+  <link rel='icon' href='/2018/favicon.ico'>
 <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-<link rel='stylesheet' href='http://us2ts.org/2018/css/main.67a788c9.css'>
+<link rel='stylesheet' href='/2018/css/main.67a788c9.css'>
 
-  <link rel='stylesheet' href='http://us2ts.org/2018/css/custom.css'>
+  <link rel='stylesheet' href='/2018/css/custom.css'>
 
 
 
@@ -30,43 +30,43 @@
 <body class='page'>
   <div class='site'>
     <header id='header' class='header-container'>
-	<div><a href="http://us2ts.org"><img src="http://us2ts.org/2018/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a> U.S. Semantic Technologies Symposium Series <br/> <div style="font-size: 70%;"> March 1-2, 2018, at Wright State University, Dayton, Ohio</div></div><hr>
+	<div><a href="/"><img src="/2018/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a> U.S. Semantic Technologies Symposium Series <br/> <div style="font-size: 70%;"> March 1-2, 2018, at Wright State University, Dayton, Ohio</div></div><hr>
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
   <ul class='main-menu'>
     
     <li>
-      <a href='http://us2ts.org/2018/' 
+      <a href='/2018/' 
         
       >About</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/program/' 
+      <a href='/2018/posts/program/' 
         
       >Program</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/registration/' 
+      <a href='/2018/posts/registration/' 
         
       >Register</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/travel/' 
+      <a href='/2018/posts/travel/' 
         
       >Accomodation</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/venue/' 
+      <a href='/2018/posts/venue/' 
         
       >Venue</a>
     </li>
     
     <li>
-      <a href='http://us2ts.org/2018/posts/sponsors/' 
+      <a href='/2018/posts/sponsors/' 
         
       >Sponsors</a>
     </li>
@@ -114,9 +114,9 @@
 </header>
 
     <div class='entry-content'>
-  <p>The event will be held at Wright State University in Dayton, OH, March 1-2, 2018. Further details about directions and transportation are available <a href="http://us2ts.org/2018/Directionsus2ts.pdf">here</a>. A map of the conference rooms and buildings is available <a href="http://us2ts.org/2018/overviewMap_V2.pdf">here</a>. The program will run from 8:30am-5pm on Thursday and 8:30am-3pm on Friday. The registration desk will be open from 8:00am on March 1, and will be located in the Lobby of the NEC (Neuroscience Engineering Collaboration) building. The plenary sessions will take place in room NEC 101, next to the registration desk.</p>
+  <p>The event will be held at Wright State University in Dayton, OH, March 1-2, 2018. Further details about directions and transportation are available <a href="/2018/Directionsus2ts.pdf">here</a>. A map of the conference rooms and buildings is available <a href="/2018/overviewMap_V2.pdf">here</a>. The program will run from 8:30am-5pm on Thursday and 8:30am-3pm on Friday. The registration desk will be open from 8:00am on March 1, and will be located in the Lobby of the NEC (Neuroscience Engineering Collaboration) building. The plenary sessions will take place in room NEC 101, next to the registration desk.</p>
 
-<p>If you come to the conference venue by car, please use Parking Lot 17 (see <a href="http://us2ts.org/2018/map.pdf">map</a>). We have special permit to use Lot 17 for the event, and it is next to the NEC and Russ buildings where the event will be held. Note that you are not allowed to park in any other lots without a university permit (with the exception of the visitor Lot 2, from which it’s a bit tricky to walk to NEC).</p>
+<p>If you come to the conference venue by car, please use Parking Lot 17 (see <a href="/2018/map.pdf">map</a>). We have special permit to use Lot 17 for the event, and it is next to the NEC and Russ buildings where the event will be held. Note that you are not allowed to park in any other lots without a university permit (with the exception of the visitor Lot 2, from which it’s a bit tricky to walk to NEC).</p>
 
 </div>
 
@@ -136,7 +136,7 @@
     
 <nav class='entry-nav'>
   <div class='entry-nav-links'><div class='prev-entry'>
-      <a href='http://us2ts.org/2018/posts/program/'>
+      <a href='/2018/posts/program/'>
         <span aria-hidden='true'><svg class='icon' viewbox='0 0 24 24' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' aria-hidden='true'>
   
   <line x1="20" y1="12" x2="4" y2="12"/>
@@ -146,7 +146,7 @@
  Previous</span>
         <span class='screen-reader'>Previous post: </span>Program</a>
     </div><div class='next-entry'>
-      <a href='http://us2ts.org/2018/posts/contributions/'>
+      <a href='/2018/posts/contributions/'>
         <span class='screen-reader'>Next post: </span>Contributions<span aria-hidden='true'>Next <svg class='icon' viewbox='0 0 24 24' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' aria-hidden='true'>
   
   <line x1="4" y1="12" x2="20" y2="12"/>
@@ -183,9 +183,9 @@
 
   </div>
 
-  <script src='http://us2ts.org/2018//main.af838dd5.js'></script>
+  <script src='/2018//main.af838dd5.js'></script>
   
-    <script src='http://us2ts.org/2018//custom.js'></script>
+    <script src='/2018//custom.js'></script>
   
 
 </body>

--- a/2019/index.html
+++ b/2019/index.html
@@ -13,16 +13,16 @@
     <meta property='og:type' content='website'>
     <meta property='og:updated_time' content='2019-02-27' />
   
-    <link rel='icon' href='http://us2ts.org/2019/favicon.ico'>
+    <link rel='icon' href='/2019/favicon.ico'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/main.67a788c9.css">
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/custom.css">
+    <link rel='stylesheet' href="/2019/css/main.67a788c9.css">
+    <link rel='stylesheet' href="/2019/css/custom.css">
   </head>
   
 <body class='home'>
   <div class='site'>
     <header id='header' class='header-container'>
-      <div><a href="http://us2ts.org"><img src="http://us2ts.org/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
+      <div><a href="/"><img src="/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
         U.S. Semantic Technologies Symposium Series <br />
         <div style="font-size: 70%;margin-left:120px;"> <b>March 11-13, 2019</b> at Duke University in Durham, NC</div>
       </div>
@@ -30,20 +30,20 @@
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
           <ul class='main-menu'>
-            <li><a href='http://us2ts.org/2019/' class='current' aria-current='page'>Home</a></li>
-            <li><a href='http://us2ts.org/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
-            <li><a href='http://us2ts.org/2019/posts/program.html' aria-current='page'>Program</a></li>
-            <li><a href='http://us2ts.org/2019/posts/registration.html' aria-current='page'>Registration</a></li>            
-            <li><a href='http://us2ts.org/2019/posts/venue.html' aria-current='page'>Venue</a></li>            
-            <li><a href='http://us2ts.org/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
-            <li><a href='http://us2ts.org/2019/posts/about.html'  aria-current='page'>About</a></li>
+            <li><a href='/2019/' class='current' aria-current='page'>Home</a></li>
+            <li><a href='/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
+            <li><a href='/2019/posts/program.html' aria-current='page'>Program</a></li>
+            <li><a href='/2019/posts/registration.html' aria-current='page'>Registration</a></li>            
+            <li><a href='/2019/posts/venue.html' aria-current='page'>Venue</a></li>            
+            <li><a href='/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
+            <li><a href='/2019/posts/about.html'  aria-current='page'>About</a></li>
             <li>
               <div class='menu-dropdown' aria-current='page'>Series
                 <ul class="main-menu menu-dropdown-content">
-                  <li><a href='http://us2ts.org/2019/' aria-current='page'>2019</a>
+                  <li><a href='/2019/' aria-current='page'>2019</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
-                  <li> <a href='http://us2ts.org/2018/' aria-current='page'>2018</a>
+                  <li> <a href='/2018/' aria-current='page'>2018</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
                 </ul>
@@ -70,8 +70,8 @@
 		  
         <p><strong>News:</strong> <a href="https://tw.rpi.edu/web/person/deborah_l_mcguinness"> Deborah McGuinness</a> will be our opening keynote speaker.</p>
         
-        <p><strong>News:</strong> <a href="http://us2ts.org/2019/posts/cfp.html" target="_blank"> Call for Posters </a>. Deadline: Feb 25, 2019 (first-come first-serve) </p>
-        <p><strong>News:</strong> <a href="http://us2ts.org/2019/posts/cfp.html" target="_blank">Call for Lightning Talks </a>. Deadline: Open until slots filled (first-come first-serve) </p>
+        <p><strong>News:</strong> <a href="/2019/posts/cfp.html" target="_blank"> Call for Posters </a>. Deadline: Feb 25, 2019 (first-come first-serve) </p>
+        <p><strong>News:</strong> <a href="/2019/posts/cfp.html" target="_blank">Call for Lightning Talks </a>. Deadline: Open until slots filled (first-come first-serve) </p>
         <p><strong>News:</strong> <a href="https://www.linkedin.com/in/helenadeus/" target="_blank">Helena Deus </a>, Technology Research Director at Elsevier will give a keynote. </p>
 	<p><strong>News:</strong> 	  The Open Bioinformatics Foundation (OBF) offers a Travel Fellowship program, with a particular focus on increasing diversity at bioinformatics-related events by helping to lower financial barriers to participation. This includes the US2TS conference. Travel awards are up to $1,000, and applications are reviewed three times a year, with the next deadline on Saturday, December 15, 2018. More information, including how to apply, can be found at <a href="https://github.com/OBF/obf-docs/blob/master/Travel_fellowships.md" target="_blank">https://github.com/OBF/obf-docs/blob/master/Travel_fellowships.md</a>
 	</p>
@@ -79,10 +79,10 @@
 	<p><strong>News:</strong> Registration now available through RegOnline. Please <a href='https://www.regonline.com/builder/site/Default.aspx?EventID=2549049&'
           target="_blank">click here</a> for registration.</p>   
       <p><strong>News:</strong> Students and early-career professionals can apply for Travel grant funded by the Alfred P.
-        Sloan Foundation and the US National Science Foundation (NSF). Please <a href='http://www.us2ts.org/2019/us2ts2019-student.pdf'
+        Sloan Foundation and the US National Science Foundation (NSF). Please <a href='/2019/us2ts2019-student.pdf'
           target="_blank">click here</a> for more details. Application Deadline: December 23, 2018 </p>
      
-      <p><strong>News:</strong> Call for Sessions Proposals. <a href='http://us2ts.org/2019/posts/cfp.html'> Click here </a>
+      <p><strong>News:</strong> Call for Sessions Proposals. <a href='/2019/posts/cfp.html'> Click here </a>
         for details. Deadline for submissions: October 31, 2018</p>
       <p><strong>News:</strong> Join our mailing list <a href="https://groups.google.com/forum/#!forum/us2ts">here</a> to
         be kept informed. </p>
@@ -123,7 +123,7 @@
         <li>Krzysztof Janowicz (Outgoing Program Chair)</li>
       </ul>
       <p>For all questions please contact the organizers at <a href="mailto:contact-us2ts2019@googlegroups.com">contact-us2ts2019@googlegroups.com</a></p>
-      <p> Past Event: <a href='http://us2ts.org/2018' target="_blank"> US2TS 2018</a> </p>
+      <p> Past Event: <a href='/2018' target="_blank"> US2TS 2018</a> </p>
     </div>
   </article>
   </main>
@@ -139,7 +139,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/program.html'>Program</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/program.html'>Program</a>
                 </h3>
               </header>
             </article>
@@ -149,7 +149,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/registration.html'>Registration</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/registration.html'>Registration</a>
                 </h3>
               </header>
             </article>
@@ -160,7 +160,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/sponsor.html'>Sponsors</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/sponsor.html'>Sponsors</a> </h3>
               </header>
             </article>
 
@@ -170,7 +170,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/venue.html'>Venue</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/venue.html'>Venue</a> </h3>
               </header>
             </article>
 
@@ -181,7 +181,7 @@
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/cfp.html'>Call for Sessions Proposals</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/cfp.html'>Call for Sessions Proposals</a>
                 </h3>
               </header>
             </article>
@@ -194,7 +194,7 @@
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/committee.html'>Steering committee</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/committee.html'>Steering committee</a>
                 </h3>
               </header>
             </article>
@@ -205,7 +205,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2018' target="_blank">Past US2TS event</a> </h3>
+                <h3 class='list-item-title'> <a href='/2018' target="_blank">Past US2TS event</a> </h3>
               </header>
             </article>
           </div>

--- a/2019/posts/about.html
+++ b/2019/posts/about.html
@@ -15,17 +15,17 @@
   <title>2nd U.S. Semantic Technologies Symposium 2019</title>
 
   <link rel='canonical' href='http://us2ts.org/2019/'>
-  <link rel='icon' href='http://us2ts.org/2019/favicon.ico'>
+  <link rel='icon' href='/2019/favicon.ico'>
   <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-  <link rel='stylesheet' href="http://us2ts.org/2019/css/main.67a788c9.css">
-  <link rel='stylesheet' href="http://us2ts.org/2019/css/custom.css">
+  <link rel='stylesheet' href="/2019/css/main.67a788c9.css">
+  <link rel='stylesheet' href="/2019/css/custom.css">
 </head>
 
 
 <body class='section'>
   <div class='site'>
     <header id='header' class='header-container'>
-      <div><a href="http://us2ts.org"><img src="http://us2ts.org/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
+      <div><a href="/"><img src="/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
         U.S. Semantic Technologies Symposium Series <br />
         <div style="font-size: 70%;margin-left:120px;"> <b>March 11-13, 2019</b> at Duke University in Durham, NC</div>
       </div>
@@ -33,20 +33,20 @@
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
           <ul class='main-menu'>
-            <li><a href='http://us2ts.org/2019/' aria-current='page'>Home</a></li>
-            <li><a href='http://us2ts.org/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
-            <li><a href='http://us2ts.org/2019/posts/program.html' aria-current='page'>Program</a></li>
-            <li><a href='http://us2ts.org/2019/posts/registration.html' aria-current='page'>Registration</a></li>            
-            <li><a href='http://us2ts.org/2019/posts/venue.html' aria-current='page'>Venue</a></li>            
-            <li><a href='http://us2ts.org/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
-            <li><a href='http://us2ts.org/2019/posts/about.html' class='current' aria-current='page'>About</a></li>
+            <li><a href='/2019/' aria-current='page'>Home</a></li>
+            <li><a href='/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
+            <li><a href='/2019/posts/program.html' aria-current='page'>Program</a></li>
+            <li><a href='/2019/posts/registration.html' aria-current='page'>Registration</a></li>            
+            <li><a href='/2019/posts/venue.html' aria-current='page'>Venue</a></li>            
+            <li><a href='/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
+            <li><a href='/2019/posts/about.html' class='current' aria-current='page'>About</a></li>
             <li>
               <div class='menu-dropdown' aria-current='page'>Series
                 <ul class="main-menu menu-dropdown-content">
-                  <li><a href='http://us2ts.org/2019/' aria-current='page'>2019</a>
+                  <li><a href='/2019/' aria-current='page'>2019</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
-                  <li> <a href='http://us2ts.org/2018/' aria-current='page'>2018</a>
+                  <li> <a href='/2018/' aria-current='page'>2018</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
                 </ul>
@@ -109,7 +109,7 @@
 				   
 				   <br/>
 				   
-				   Please see <a href="http://us2ts.org/2019/posts/coc.html"> Code of Conduct </a> page for details.
+				   Please see <a href="/2019/posts/coc.html"> Code of Conduct </a> page for details.
 				   				  
 				  </p>
           </div>
@@ -126,7 +126,7 @@
                   </span>
                 </div>
                 <header class='list-item-header'>
-                  <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/program.html'>Program</a>
+                  <h3 class='list-item-title'> <a href='/2019/posts/program.html'>Program</a>
                   </h3>
                 </header>
               </article>
@@ -136,7 +136,7 @@
                   </span>
                 </div>
                 <header class='list-item-header'>
-                  <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/registration.html'>Registration</a>
+                  <h3 class='list-item-title'> <a href='/2019/posts/registration.html'>Registration</a>
                   </h3>
                 </header>
               </article>
@@ -147,7 +147,7 @@
                   </span>
                 </div>
                 <header class='list-item-header'>
-                  <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/sponsor.html'>Sponsors</a> </h3>
+                  <h3 class='list-item-title'> <a href='/2019/posts/sponsor.html'>Sponsors</a> </h3>
                 </header>
               </article>
   
@@ -157,7 +157,7 @@
                   </span>
                 </div>
                 <header class='list-item-header'>
-                  <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/venue.html'>Venue</a> </h3>
+                  <h3 class='list-item-title'> <a href='/2019/posts/venue.html'>Venue</a> </h3>
                 </header>
               </article>
   
@@ -168,7 +168,7 @@
   
                 </div>
                 <header class='list-item-header'>
-                  <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/cfp.html'>Call for Sessions Proposals</a>
+                  <h3 class='list-item-title'> <a href='/2019/posts/cfp.html'>Call for Sessions Proposals</a>
                   </h3>
                 </header>
               </article>
@@ -181,7 +181,7 @@
   
                 </div>
                 <header class='list-item-header'>
-                  <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/committee.html'>Steering committee</a>
+                  <h3 class='list-item-title'> <a href='/2019/posts/committee.html'>Steering committee</a>
                   </h3>
                 </header>
               </article>
@@ -192,7 +192,7 @@
                   </span>
                 </div>
                 <header class='list-item-header'>
-                  <h3 class='list-item-title'> <a href='http://us2ts.org/2018' target="_blank">Past US2TS event</a> </h3>
+                  <h3 class='list-item-title'> <a href='/2018' target="_blank">Past US2TS event</a> </h3>
                 </header>
               </article>
             </div>

--- a/2019/posts/cfp.html
+++ b/2019/posts/cfp.html
@@ -15,17 +15,17 @@
     <title>2nd U.S. Semantic Technologies Symposium 2019</title>
   
     <link rel='canonical' href='http://us2ts.org/2019/'>
-    <link rel='icon' href='http://us2ts.org/2019/favicon.ico'>
+    <link rel='icon' href='/2019/favicon.ico'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/main.67a788c9.css">
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/custom.css">
+    <link rel='stylesheet' href="/2019/css/main.67a788c9.css">
+    <link rel='stylesheet' href="/2019/css/custom.css">
   </head>
   
 
 <body class='home'>
   <div class='site'>
     <header id='header' class='header-container'>
-      <div><a href="http://us2ts.org"><img src="http://us2ts.org/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
+      <div><a href="/"><img src="/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
         U.S. Semantic Technologies Symposium Series <br />
         <div style="font-size: 70%;margin-left:120px;"> <b>March 11-13, 2019</b> at Duke University in Durham, NC</div>
       </div>
@@ -33,20 +33,20 @@
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
           <ul class='main-menu'>
-            <li><a href='http://us2ts.org/2019/' aria-current='page'>Home</a></li>
-            <li><a href='http://us2ts.org/2019/posts/cfp.html' class='current' aria-current='page'>Calls</a></li>
-            <li><a href='http://us2ts.org/2019/posts/program.html' aria-current='page'>Program</a></li>
-            <li><a href='http://us2ts.org/2019/posts/registration.html' aria-current='page'>Registration</a></li>
-            <li><a href='http://us2ts.org/2019/posts/venue.html' aria-current='page'>Venue</a></li>
-            <li><a href='http://us2ts.org/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
-            <li><a href='http://us2ts.org/2019/posts/about.html' aria-current='page'>About</a></li>
+            <li><a href='/2019/' aria-current='page'>Home</a></li>
+            <li><a href='/2019/posts/cfp.html' class='current' aria-current='page'>Calls</a></li>
+            <li><a href='/2019/posts/program.html' aria-current='page'>Program</a></li>
+            <li><a href='/2019/posts/registration.html' aria-current='page'>Registration</a></li>
+            <li><a href='/2019/posts/venue.html' aria-current='page'>Venue</a></li>
+            <li><a href='/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
+            <li><a href='/2019/posts/about.html' aria-current='page'>About</a></li>
             <li>
               <div class='menu-dropdown' aria-current='page'>Series
                 <ul class="main-menu menu-dropdown-content">
-                  <li><a href='http://us2ts.org/2019/' aria-current='page'>2019</a>
+                  <li><a href='/2019/' aria-current='page'>2019</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
-                  <li> <a href='http://us2ts.org/2018/' aria-current='page'>2018</a>
+                  <li> <a href='/2018/' aria-current='page'>2018</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
                 </ul>
@@ -266,7 +266,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/program.html'>Program</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/program.html'>Program</a>
                 </h3>
               </header>
             </article>
@@ -276,7 +276,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/registration.html'>Registration</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/registration.html'>Registration</a>
                 </h3>
               </header>
             </article>
@@ -287,7 +287,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/sponsor.html'>Sponsors</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/sponsor.html'>Sponsors</a> </h3>
               </header>
             </article>
 
@@ -297,7 +297,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/venue.html'>Venue</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/venue.html'>Venue</a> </h3>
               </header>
             </article>
 
@@ -308,7 +308,7 @@
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/cfp.html'>Call for Sessions Proposals</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/cfp.html'>Call for Sessions Proposals</a>
                 </h3>
               </header>
             </article>
@@ -321,7 +321,7 @@
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/committee.html'>Steering committee</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/committee.html'>Steering committee</a>
                 </h3>
               </header>
             </article>
@@ -332,7 +332,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2018' target="_blank">Past US2TS event</a> </h3>
+                <h3 class='list-item-title'> <a href='/2018' target="_blank">Past US2TS event</a> </h3>
               </header>
             </article>
           </div>

--- a/2019/posts/coc.html
+++ b/2019/posts/coc.html
@@ -16,17 +16,17 @@
   <title>2nd U.S. Semantic Technologies Symposium 2019</title>
 
   <link rel='canonical' href='http://us2ts.org/2019/'>
-  <link rel='icon' href='http://us2ts.org/2019/favicon.ico'>
+  <link rel='icon' href='/2019/favicon.ico'>
   <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-  <link rel='stylesheet' href="http://us2ts.org/2019/css/main.67a788c9.css">
-  <link rel='stylesheet' href="http://us2ts.org/2019/css/custom.css">
+  <link rel='stylesheet' href="/2019/css/main.67a788c9.css">
+  <link rel='stylesheet' href="/2019/css/custom.css">
 </head>
 
 
 <body class='section'>
   <div class='site'>
     <header id='header' class='header-container'>
-      <div><a href="http://us2ts.org"><img src="http://us2ts.org/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
+      <div><a href="/"><img src="/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
         U.S. Semantic Technologies Symposium Series <br />
         <div style="font-size: 70%;margin-left:120px;"> <b>March 11-13, 2019</b> at Duke University in Durham, NC</div>
       </div>
@@ -34,20 +34,20 @@
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
           <ul class='main-menu'>
-            <li><a href='http://us2ts.org/2019/' aria-current='page'>Home</a></li>
-            <li><a href='http://us2ts.org/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
-            <li><a href='http://us2ts.org/2019/posts/program.html' aria-current='page'>Program</a></li>
-            <li><a href='http://us2ts.org/2019/posts/registration.html' aria-current='page'>Registration</a></li>            
-            <li><a href='http://us2ts.org/2019/posts/venue.html' aria-current='page'>Venue</a></li>            
-            <li><a href='http://us2ts.org/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
-            <li><a href='http://us2ts.org/2019/posts/about.html' class='current' aria-current='page'>About</a></li>
+            <li><a href='/2019/' aria-current='page'>Home</a></li>
+            <li><a href='/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
+            <li><a href='/2019/posts/program.html' aria-current='page'>Program</a></li>
+            <li><a href='/2019/posts/registration.html' aria-current='page'>Registration</a></li>            
+            <li><a href='/2019/posts/venue.html' aria-current='page'>Venue</a></li>            
+            <li><a href='/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
+            <li><a href='/2019/posts/about.html' class='current' aria-current='page'>About</a></li>
             <li>
               <div class='menu-dropdown' aria-current='page'>Series
                 <ul class="main-menu menu-dropdown-content">
-                  <li><a href='http://us2ts.org/2019/' aria-current='page'>2019</a>
+                  <li><a href='/2019/' aria-current='page'>2019</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
-                  <li> <a href='http://us2ts.org/2018/' aria-current='page'>2018</a>
+                  <li> <a href='/2018/' aria-current='page'>2018</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
                 </ul>
@@ -153,7 +153,7 @@ This code of conduct complements all legal rights that apply to particular situa
                   </span>
                 </div>
                 <header class='list-item-header'>
-                  <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/program.html'>Program</a>
+                  <h3 class='list-item-title'> <a href='/2019/posts/program.html'>Program</a>
                   </h3>
                 </header>
               </article>
@@ -163,7 +163,7 @@ This code of conduct complements all legal rights that apply to particular situa
                   </span>
                 </div>
                 <header class='list-item-header'>
-                  <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/registration.html'>Registration</a>
+                  <h3 class='list-item-title'> <a href='/2019/posts/registration.html'>Registration</a>
                   </h3>
                 </header>
               </article>
@@ -174,7 +174,7 @@ This code of conduct complements all legal rights that apply to particular situa
                   </span>
                 </div>
                 <header class='list-item-header'>
-                  <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/sponsor.html'>Sponsors</a> </h3>
+                  <h3 class='list-item-title'> <a href='/2019/posts/sponsor.html'>Sponsors</a> </h3>
                 </header>
               </article>
   
@@ -184,7 +184,7 @@ This code of conduct complements all legal rights that apply to particular situa
                   </span>
                 </div>
                 <header class='list-item-header'>
-                  <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/venue.html'>Venue</a> </h3>
+                  <h3 class='list-item-title'> <a href='/2019/posts/venue.html'>Venue</a> </h3>
                 </header>
               </article>
   
@@ -195,7 +195,7 @@ This code of conduct complements all legal rights that apply to particular situa
   
                 </div>
                 <header class='list-item-header'>
-                  <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/cfp.html'>Call for Sessions Proposals</a>
+                  <h3 class='list-item-title'> <a href='/2019/posts/cfp.html'>Call for Sessions Proposals</a>
                   </h3>
                 </header>
               </article>
@@ -208,7 +208,7 @@ This code of conduct complements all legal rights that apply to particular situa
   
                 </div>
                 <header class='list-item-header'>
-                  <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/committee.html'>Steering committee</a>
+                  <h3 class='list-item-title'> <a href='/2019/posts/committee.html'>Steering committee</a>
                   </h3>
                 </header>
               </article>
@@ -219,7 +219,7 @@ This code of conduct complements all legal rights that apply to particular situa
                   </span>
                 </div>
                 <header class='list-item-header'>
-                  <h3 class='list-item-title'> <a href='http://us2ts.org/2018' target="_blank">Past US2TS event</a> </h3>
+                  <h3 class='list-item-title'> <a href='/2018' target="_blank">Past US2TS event</a> </h3>
                 </header>
               </article>
             </div>

--- a/2019/posts/committee.html
+++ b/2019/posts/committee.html
@@ -15,16 +15,16 @@
     <title>2nd U.S. Semantic Technologies Symposium 2019</title>
   
     <link rel='canonical' href='http://us2ts.org/2019/'>
-    <link rel='icon' href='http://us2ts.org/2019/favicon.ico'>
+    <link rel='icon' href='/2019/favicon.ico'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/main.67a788c9.css">
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/custom.css">
+    <link rel='stylesheet' href="/2019/css/main.67a788c9.css">
+    <link rel='stylesheet' href="/2019/css/custom.css">
   </head>
   
 <body class='home'>
   <div class='site'>
     <header id='header' class='header-container'>
-      <div><a href="http://us2ts.org"><img src="http://us2ts.org/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
+      <div><a href="/"><img src="/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
         U.S. Semantic Technologies Symposium Series <br />
         <div style="font-size: 70%;margin-left:120px;"> <b>March 11-13, 2019</b> at Duke University in Durham, NC</div>
       </div>
@@ -32,20 +32,20 @@
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
           <ul class='main-menu'>
-            <li><a href='http://us2ts.org/2019/' aria-current='page'>Home</a></li>
-            <li><a href='http://us2ts.org/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
-            <li><a href='http://us2ts.org/2019/posts/program.html' aria-current='page'>Program</a></li>
-            <li><a href='http://us2ts.org/2019/posts/registration.html' aria-current='page'>Registration</a></li>
-            <li><a href='http://us2ts.org/2019/posts/venue.html' aria-current='page'>Venue</a></li>
-            <li><a href='http://us2ts.org/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
-            <li><a href='http://us2ts.org/2019/posts/about.html' class='current' aria-current='page'>About</a></li>
+            <li><a href='/2019/' aria-current='page'>Home</a></li>
+            <li><a href='/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
+            <li><a href='/2019/posts/program.html' aria-current='page'>Program</a></li>
+            <li><a href='/2019/posts/registration.html' aria-current='page'>Registration</a></li>
+            <li><a href='/2019/posts/venue.html' aria-current='page'>Venue</a></li>
+            <li><a href='/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
+            <li><a href='/2019/posts/about.html' class='current' aria-current='page'>About</a></li>
             <li>
               <div class='menu-dropdown' aria-current='page'>Series
                 <ul class="main-menu menu-dropdown-content">
-                  <li><a href='http://us2ts.org/2019/' aria-current='page'>2019</a>
+                  <li><a href='/2019/' aria-current='page'>2019</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
-                  <li> <a href='http://us2ts.org/2018/' aria-current='page'>2018</a>
+                  <li> <a href='/2018/' aria-current='page'>2018</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
                 </ul>
@@ -123,7 +123,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/program.html'>Program</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/program.html'>Program</a>
                 </h3>
               </header>
             </article>
@@ -133,7 +133,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/registration.html'>Registration</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/registration.html'>Registration</a>
                 </h3>
               </header>
             </article>
@@ -144,7 +144,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/sponsor.html'>Sponsors</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/sponsor.html'>Sponsors</a> </h3>
               </header>
             </article>
 
@@ -154,7 +154,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/venue.html'>Venue</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/venue.html'>Venue</a> </h3>
               </header>
             </article>
 
@@ -165,7 +165,7 @@
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/cfp.html'>Call for Sessions Proposals</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/cfp.html'>Call for Sessions Proposals</a>
                 </h3>
               </header>
             </article>
@@ -178,7 +178,7 @@
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/committee.html'>Steering committee</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/committee.html'>Steering committee</a>
                 </h3>
               </header>
             </article>
@@ -189,7 +189,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2018' target="_blank">Past US2TS event</a> </h3>
+                <h3 class='list-item-title'> <a href='/2018' target="_blank">Past US2TS event</a> </h3>
               </header>
             </article>
           </div>

--- a/2019/posts/program-session-i.html
+++ b/2019/posts/program-session-i.html
@@ -15,16 +15,16 @@
     <title>2nd U.S. Semantic Technologies Symposium 2019</title>
   
     <link rel='canonical' href='http://us2ts.org/2019/'>
-    <link rel='icon' href='http://us2ts.org/2019/favicon.ico'>
+    <link rel='icon' href='/2019/favicon.ico'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/main.67a788c9.css">
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/custom.css">
+    <link rel='stylesheet' href="/2019/css/main.67a788c9.css">
+    <link rel='stylesheet' href="/2019/css/custom.css">
   </head>
   
 <body class='home'>
   <div class='site'>
     <header id='header' class='header-container'>
-      <div><a href="http://us2ts.org"><img src="http://us2ts.org/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
+      <div><a href="/"><img src="/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
         U.S. Semantic Technologies Symposium Series <br />
         <div style="font-size: 70%;margin-left:120px;"> <b>March 11-13, 2019</b> at Duke University in Durham, NC</div>
       </div>
@@ -32,20 +32,20 @@
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
           <ul class='main-menu'>
-            <li><a href='http://us2ts.org/2019/' aria-current='page'>Home</a></li>
-            <li><a href='http://us2ts.org/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
-            <li><a href='http://us2ts.org/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
-            <li><a href='http://us2ts.org/2019/posts/registration.html' aria-current='page'>Registration</a></li>
-            <li><a href='http://us2ts.org/2019/posts/venue.html' aria-current='page'>Venue</a></li>
-            <li><a href='http://us2ts.org/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
-            <li><a href='http://us2ts.org/2019/posts/about.html' aria-current='page'>About</a></li>
+            <li><a href='/2019/' aria-current='page'>Home</a></li>
+            <li><a href='/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
+            <li><a href='/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
+            <li><a href='/2019/posts/registration.html' aria-current='page'>Registration</a></li>
+            <li><a href='/2019/posts/venue.html' aria-current='page'>Venue</a></li>
+            <li><a href='/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
+            <li><a href='/2019/posts/about.html' aria-current='page'>About</a></li>
             <li>
               <div class='menu-dropdown' aria-current='page'>Series
                 <ul class="main-menu menu-dropdown-content">
-                  <li><a href='http://us2ts.org/2019/' aria-current='page'>2019</a>
+                  <li><a href='/2019/' aria-current='page'>2019</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
-                  <li> <a href='http://us2ts.org/2018/' aria-current='page'>2018</a>
+                  <li> <a href='/2018/' aria-current='page'>2018</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
                 </ul>
@@ -132,7 +132,7 @@ Joshua Shinavier (Uber)
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/program.html'>Program</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/program.html'>Program</a>
                 </h3>
               </header>
             </article>
@@ -142,7 +142,7 @@ Joshua Shinavier (Uber)
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/registration.html'>Registration</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/registration.html'>Registration</a>
                 </h3>
               </header>
             </article>
@@ -153,7 +153,7 @@ Joshua Shinavier (Uber)
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/sponsor.html'>Sponsors</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/sponsor.html'>Sponsors</a> </h3>
               </header>
             </article>
 
@@ -163,7 +163,7 @@ Joshua Shinavier (Uber)
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/venue.html'>Venue</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/venue.html'>Venue</a> </h3>
               </header>
             </article>
 
@@ -174,7 +174,7 @@ Joshua Shinavier (Uber)
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/cfp.html'>Call for Sessions Proposals</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/cfp.html'>Call for Sessions Proposals</a>
                 </h3>
               </header>
             </article>
@@ -187,7 +187,7 @@ Joshua Shinavier (Uber)
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/committee.html'>Steering committee</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/committee.html'>Steering committee</a>
                 </h3>
               </header>
             </article>
@@ -198,7 +198,7 @@ Joshua Shinavier (Uber)
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2018' target="_blank">Past US2TS event</a> </h3>
+                <h3 class='list-item-title'> <a href='/2018' target="_blank">Past US2TS event</a> </h3>
               </header>
             </article>
           </div>

--- a/2019/posts/program-session-ii.html
+++ b/2019/posts/program-session-ii.html
@@ -15,16 +15,16 @@
     <title>2nd U.S. Semantic Technologies Symposium 2019</title>
   
     <link rel='canonical' href='http://us2ts.org/2019/'>
-    <link rel='icon' href='http://us2ts.org/2019/favicon.ico'>
+    <link rel='icon' href='/2019/favicon.ico'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/main.67a788c9.css">
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/custom.css">
+    <link rel='stylesheet' href="/2019/css/main.67a788c9.css">
+    <link rel='stylesheet' href="/2019/css/custom.css">
   </head>
   
 <body class='home'>
   <div class='site'>
     <header id='header' class='header-container'>
-      <div><a href="http://us2ts.org"><img src="http://us2ts.org/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
+      <div><a href="/"><img src="/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
         U.S. Semantic Technologies Symposium Series <br />
         <div style="font-size: 70%;margin-left:120px;"> <b>March 11-13, 2019</b> at Duke University in Durham, NC</div>
       </div>
@@ -32,20 +32,20 @@
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
           <ul class='main-menu'>
-            <li><a href='http://us2ts.org/2019/' aria-current='page'>Home</a></li>
-            <li><a href='http://us2ts.org/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
-            <li><a href='http://us2ts.org/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
-            <li><a href='http://us2ts.org/2019/posts/registration.html' aria-current='page'>Registration</a></li>
-            <li><a href='http://us2ts.org/2019/posts/venue.html' aria-current='page'>Venue</a></li>
-            <li><a href='http://us2ts.org/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
-            <li><a href='http://us2ts.org/2019/posts/about.html' aria-current='page'>About</a></li>
+            <li><a href='/2019/' aria-current='page'>Home</a></li>
+            <li><a href='/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
+            <li><a href='/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
+            <li><a href='/2019/posts/registration.html' aria-current='page'>Registration</a></li>
+            <li><a href='/2019/posts/venue.html' aria-current='page'>Venue</a></li>
+            <li><a href='/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
+            <li><a href='/2019/posts/about.html' aria-current='page'>About</a></li>
             <li>
               <div class='menu-dropdown' aria-current='page'>Series
                 <ul class="main-menu menu-dropdown-content">
-                  <li><a href='http://us2ts.org/2019/' aria-current='page'>2019</a>
+                  <li><a href='/2019/' aria-current='page'>2019</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
-                  <li> <a href='http://us2ts.org/2018/' aria-current='page'>2018</a>
+                  <li> <a href='/2018/' aria-current='page'>2018</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
                 </ul>
@@ -135,7 +135,7 @@ This session brings together disparate elements of the geospatial semantics comm
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/program.html'>Program</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/program.html'>Program</a>
                 </h3>
               </header>
             </article>
@@ -145,7 +145,7 @@ This session brings together disparate elements of the geospatial semantics comm
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/registration.html'>Registration</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/registration.html'>Registration</a>
                 </h3>
               </header>
             </article>
@@ -156,7 +156,7 @@ This session brings together disparate elements of the geospatial semantics comm
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/sponsor.html'>Sponsors</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/sponsor.html'>Sponsors</a> </h3>
               </header>
             </article>
 
@@ -166,7 +166,7 @@ This session brings together disparate elements of the geospatial semantics comm
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/venue.html'>Venue</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/venue.html'>Venue</a> </h3>
               </header>
             </article>
 
@@ -177,7 +177,7 @@ This session brings together disparate elements of the geospatial semantics comm
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/cfp.html'>Call for Sessions Proposals</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/cfp.html'>Call for Sessions Proposals</a>
                 </h3>
               </header>
             </article>
@@ -190,7 +190,7 @@ This session brings together disparate elements of the geospatial semantics comm
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/committee.html'>Steering committee</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/committee.html'>Steering committee</a>
                 </h3>
               </header>
             </article>
@@ -201,7 +201,7 @@ This session brings together disparate elements of the geospatial semantics comm
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2018' target="_blank">Past US2TS event</a> </h3>
+                <h3 class='list-item-title'> <a href='/2018' target="_blank">Past US2TS event</a> </h3>
               </header>
             </article>
           </div>

--- a/2019/posts/program-session-iii.html
+++ b/2019/posts/program-session-iii.html
@@ -15,16 +15,16 @@
     <title>2nd U.S. Semantic Technologies Symposium 2019</title>
   
     <link rel='canonical' href='http://us2ts.org/2019/'>
-    <link rel='icon' href='http://us2ts.org/2019/favicon.ico'>
+    <link rel='icon' href='/2019/favicon.ico'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/main.67a788c9.css">
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/custom.css">
+    <link rel='stylesheet' href="/2019/css/main.67a788c9.css">
+    <link rel='stylesheet' href="/2019/css/custom.css">
   </head>
   
 <body class='home'>
   <div class='site'>
     <header id='header' class='header-container'>
-      <div><a href="http://us2ts.org"><img src="http://us2ts.org/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
+      <div><a href="/"><img src="/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
         U.S. Semantic Technologies Symposium Series <br />
         <div style="font-size: 70%;margin-left:120px;"> <b>March 11-13, 2019</b> at Duke University in Durham, NC</div>
       </div>
@@ -32,20 +32,20 @@
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
           <ul class='main-menu'>
-            <li><a href='http://us2ts.org/2019/' aria-current='page'>Home</a></li>
-            <li><a href='http://us2ts.org/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
-            <li><a href='http://us2ts.org/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
-            <li><a href='http://us2ts.org/2019/posts/registration.html' aria-current='page'>Registration</a></li>
-            <li><a href='http://us2ts.org/2019/posts/venue.html' aria-current='page'>Venue</a></li>
-            <li><a href='http://us2ts.org/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
-            <li><a href='http://us2ts.org/2019/posts/about.html' aria-current='page'>About</a></li>
+            <li><a href='/2019/' aria-current='page'>Home</a></li>
+            <li><a href='/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
+            <li><a href='/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
+            <li><a href='/2019/posts/registration.html' aria-current='page'>Registration</a></li>
+            <li><a href='/2019/posts/venue.html' aria-current='page'>Venue</a></li>
+            <li><a href='/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
+            <li><a href='/2019/posts/about.html' aria-current='page'>About</a></li>
             <li>
               <div class='menu-dropdown' aria-current='page'>Series
                 <ul class="main-menu menu-dropdown-content">
-                  <li><a href='http://us2ts.org/2019/' aria-current='page'>2019</a>
+                  <li><a href='/2019/' aria-current='page'>2019</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
-                  <li> <a href='http://us2ts.org/2018/' aria-current='page'>2018</a>
+                  <li> <a href='/2018/' aria-current='page'>2018</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
                 </ul>
@@ -106,7 +106,7 @@ This tutorial aims at exposing existing solutions towards XAI, their limitations
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/program.html'>Program</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/program.html'>Program</a>
                 </h3>
               </header>
             </article>
@@ -116,7 +116,7 @@ This tutorial aims at exposing existing solutions towards XAI, their limitations
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/registration.html'>Registration</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/registration.html'>Registration</a>
                 </h3>
               </header>
             </article>
@@ -127,7 +127,7 @@ This tutorial aims at exposing existing solutions towards XAI, their limitations
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/sponsor.html'>Sponsors</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/sponsor.html'>Sponsors</a> </h3>
               </header>
             </article>
 
@@ -137,7 +137,7 @@ This tutorial aims at exposing existing solutions towards XAI, their limitations
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/venue.html'>Venue</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/venue.html'>Venue</a> </h3>
               </header>
             </article>
 
@@ -148,7 +148,7 @@ This tutorial aims at exposing existing solutions towards XAI, their limitations
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/cfp.html'>Call for Sessions Proposals</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/cfp.html'>Call for Sessions Proposals</a>
                 </h3>
               </header>
             </article>
@@ -161,7 +161,7 @@ This tutorial aims at exposing existing solutions towards XAI, their limitations
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/committee.html'>Steering committee</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/committee.html'>Steering committee</a>
                 </h3>
               </header>
             </article>
@@ -172,7 +172,7 @@ This tutorial aims at exposing existing solutions towards XAI, their limitations
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2018' target="_blank">Past US2TS event</a> </h3>
+                <h3 class='list-item-title'> <a href='/2018' target="_blank">Past US2TS event</a> </h3>
               </header>
             </article>
           </div>

--- a/2019/posts/program-session-iv.html
+++ b/2019/posts/program-session-iv.html
@@ -15,16 +15,16 @@
     <title>2nd U.S. Semantic Technologies Symposium 2019</title>
   
     <link rel='canonical' href='http://us2ts.org/2019/'>
-    <link rel='icon' href='http://us2ts.org/2019/favicon.ico'>
+    <link rel='icon' href='/2019/favicon.ico'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/main.67a788c9.css">
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/custom.css">
+    <link rel='stylesheet' href="/2019/css/main.67a788c9.css">
+    <link rel='stylesheet' href="/2019/css/custom.css">
   </head>
   
 <body class='home'>
   <div class='site'>
     <header id='header' class='header-container'>
-      <div><a href="http://us2ts.org"><img src="http://us2ts.org/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
+      <div><a href="/"><img src="/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
         U.S. Semantic Technologies Symposium Series <br />
         <div style="font-size: 70%;margin-left:120px;"> <b>March 11-13, 2019</b> at Duke University in Durham, NC</div>
       </div>
@@ -32,20 +32,20 @@
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
           <ul class='main-menu'>
-            <li><a href='http://us2ts.org/2019/' aria-current='page'>Home</a></li>
-            <li><a href='http://us2ts.org/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
-            <li><a href='http://us2ts.org/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
-            <li><a href='http://us2ts.org/2019/posts/registration.html' aria-current='page'>Registration</a></li>
-            <li><a href='http://us2ts.org/2019/posts/venue.html' aria-current='page'>Venue</a></li>
-            <li><a href='http://us2ts.org/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
-            <li><a href='http://us2ts.org/2019/posts/about.html' aria-current='page'>About</a></li>
+            <li><a href='/2019/' aria-current='page'>Home</a></li>
+            <li><a href='/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
+            <li><a href='/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
+            <li><a href='/2019/posts/registration.html' aria-current='page'>Registration</a></li>
+            <li><a href='/2019/posts/venue.html' aria-current='page'>Venue</a></li>
+            <li><a href='/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
+            <li><a href='/2019/posts/about.html' aria-current='page'>About</a></li>
             <li>
               <div class='menu-dropdown' aria-current='page'>Series
                 <ul class="main-menu menu-dropdown-content">
-                  <li><a href='http://us2ts.org/2019/' aria-current='page'>2019</a>
+                  <li><a href='/2019/' aria-current='page'>2019</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
-                  <li> <a href='http://us2ts.org/2018/' aria-current='page'>2018</a>
+                  <li> <a href='/2018/' aria-current='page'>2018</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
                 </ul>
@@ -127,7 +127,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/program.html'>Program</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/program.html'>Program</a>
                 </h3>
               </header>
             </article>
@@ -137,7 +137,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/registration.html'>Registration</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/registration.html'>Registration</a>
                 </h3>
               </header>
             </article>
@@ -148,7 +148,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/sponsor.html'>Sponsors</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/sponsor.html'>Sponsors</a> </h3>
               </header>
             </article>
 
@@ -158,7 +158,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/venue.html'>Venue</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/venue.html'>Venue</a> </h3>
               </header>
             </article>
 
@@ -169,7 +169,7 @@
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/cfp.html'>Call for Sessions Proposals</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/cfp.html'>Call for Sessions Proposals</a>
                 </h3>
               </header>
             </article>
@@ -182,7 +182,7 @@
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/committee.html'>Steering committee</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/committee.html'>Steering committee</a>
                 </h3>
               </header>
             </article>
@@ -193,7 +193,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2018' target="_blank">Past US2TS event</a> </h3>
+                <h3 class='list-item-title'> <a href='/2018' target="_blank">Past US2TS event</a> </h3>
               </header>
             </article>
           </div>

--- a/2019/posts/program-session-ix.html
+++ b/2019/posts/program-session-ix.html
@@ -15,16 +15,16 @@
     <title>2nd U.S. Semantic Technologies Symposium 2019</title>
   
     <link rel='canonical' href='http://us2ts.org/2019/'>
-    <link rel='icon' href='http://us2ts.org/2019/favicon.ico'>
+    <link rel='icon' href='/2019/favicon.ico'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/main.67a788c9.css">
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/custom.css">
+    <link rel='stylesheet' href="/2019/css/main.67a788c9.css">
+    <link rel='stylesheet' href="/2019/css/custom.css">
   </head>
   
 <body class='home'>
   <div class='site'>
     <header id='header' class='header-container'>
-      <div><a href="http://us2ts.org"><img src="http://us2ts.org/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
+      <div><a href="/"><img src="/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
         U.S. Semantic Technologies Symposium Series <br />
         <div style="font-size: 70%;margin-left:120px;"> <b>March 11-13, 2019</b> at Duke University in Durham, NC</div>
       </div>
@@ -32,20 +32,20 @@
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
           <ul class='main-menu'>
-            <li><a href='http://us2ts.org/2019/' aria-current='page'>Home</a></li>
-            <li><a href='http://us2ts.org/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
-            <li><a href='http://us2ts.org/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
-            <li><a href='http://us2ts.org/2019/posts/registration.html' aria-current='page'>Registration</a></li>
-            <li><a href='http://us2ts.org/2019/posts/venue.html' aria-current='page'>Venue</a></li>
-            <li><a href='http://us2ts.org/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
-            <li><a href='http://us2ts.org/2019/posts/about.html' aria-current='page'>About</a></li>
+            <li><a href='/2019/' aria-current='page'>Home</a></li>
+            <li><a href='/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
+            <li><a href='/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
+            <li><a href='/2019/posts/registration.html' aria-current='page'>Registration</a></li>
+            <li><a href='/2019/posts/venue.html' aria-current='page'>Venue</a></li>
+            <li><a href='/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
+            <li><a href='/2019/posts/about.html' aria-current='page'>About</a></li>
             <li>
               <div class='menu-dropdown' aria-current='page'>Series
                 <ul class="main-menu menu-dropdown-content">
-                  <li><a href='http://us2ts.org/2019/' aria-current='page'>2019</a>
+                  <li><a href='/2019/' aria-current='page'>2019</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
-                  <li> <a href='http://us2ts.org/2018/' aria-current='page'>2018</a>
+                  <li> <a href='/2018/' aria-current='page'>2018</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
                 </ul>
@@ -99,7 +99,7 @@ This session describes OCLC's recently completed pilot using MediaWiki and WikiB
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/program.html'>Program</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/program.html'>Program</a>
                 </h3>
               </header>
             </article>
@@ -109,7 +109,7 @@ This session describes OCLC's recently completed pilot using MediaWiki and WikiB
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/registration.html'>Registration</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/registration.html'>Registration</a>
                 </h3>
               </header>
             </article>
@@ -120,7 +120,7 @@ This session describes OCLC's recently completed pilot using MediaWiki and WikiB
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/sponsor.html'>Sponsors</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/sponsor.html'>Sponsors</a> </h3>
               </header>
             </article>
 
@@ -130,7 +130,7 @@ This session describes OCLC's recently completed pilot using MediaWiki and WikiB
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/venue.html'>Venue</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/venue.html'>Venue</a> </h3>
               </header>
             </article>
 
@@ -141,7 +141,7 @@ This session describes OCLC's recently completed pilot using MediaWiki and WikiB
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/cfp.html'>Call for Sessions Proposals</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/cfp.html'>Call for Sessions Proposals</a>
                 </h3>
               </header>
             </article>
@@ -154,7 +154,7 @@ This session describes OCLC's recently completed pilot using MediaWiki and WikiB
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/committee.html'>Steering committee</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/committee.html'>Steering committee</a>
                 </h3>
               </header>
             </article>
@@ -165,7 +165,7 @@ This session describes OCLC's recently completed pilot using MediaWiki and WikiB
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2018' target="_blank">Past US2TS event</a> </h3>
+                <h3 class='list-item-title'> <a href='/2018' target="_blank">Past US2TS event</a> </h3>
               </header>
             </article>
           </div>

--- a/2019/posts/program-session-keynote-deborah.html
+++ b/2019/posts/program-session-keynote-deborah.html
@@ -15,16 +15,16 @@
     <title>2nd U.S. Semantic Technologies Symposium 2019</title>
   
     <link rel='canonical' href='http://us2ts.org/2019/'>
-    <link rel='icon' href='http://us2ts.org/2019/favicon.ico'>
+    <link rel='icon' href='/2019/favicon.ico'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/main.67a788c9.css">
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/custom.css">
+    <link rel='stylesheet' href="/2019/css/main.67a788c9.css">
+    <link rel='stylesheet' href="/2019/css/custom.css">
   </head>
   
 <body class='home'>
   <div class='site'>
     <header id='header' class='header-container'>
-      <div><a href="http://us2ts.org"><img src="http://us2ts.org/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
+      <div><a href="/"><img src="/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
         U.S. Semantic Technologies Symposium Series <br />
         <div style="font-size: 70%;margin-left:120px;"> <b>March 11-13, 2019</b> at Duke University in Durham, NC</div>
       </div>
@@ -32,20 +32,20 @@
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
           <ul class='main-menu'>
-            <li><a href='http://us2ts.org/2019/' aria-current='page'>Home</a></li>
-            <li><a href='http://us2ts.org/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
-            <li><a href='http://us2ts.org/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
-            <li><a href='http://us2ts.org/2019/posts/registration.html' aria-current='page'>Registration</a></li>
-            <li><a href='http://us2ts.org/2019/posts/venue.html' aria-current='page'>Venue</a></li>
-            <li><a href='http://us2ts.org/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
-            <li><a href='http://us2ts.org/2019/posts/about.html' aria-current='page'>About</a></li>
+            <li><a href='/2019/' aria-current='page'>Home</a></li>
+            <li><a href='/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
+            <li><a href='/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
+            <li><a href='/2019/posts/registration.html' aria-current='page'>Registration</a></li>
+            <li><a href='/2019/posts/venue.html' aria-current='page'>Venue</a></li>
+            <li><a href='/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
+            <li><a href='/2019/posts/about.html' aria-current='page'>About</a></li>
             <li>
               <div class='menu-dropdown' aria-current='page'>Series
                 <ul class="main-menu menu-dropdown-content">
-                  <li><a href='http://us2ts.org/2019/' aria-current='page'>2019</a>
+                  <li><a href='/2019/' aria-current='page'>2019</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
-                  <li> <a href='http://us2ts.org/2018/' aria-current='page'>2018</a>
+                  <li> <a href='/2018/' aria-current='page'>2018</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
                 </ul>
@@ -91,7 +91,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/program.html'>Program</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/program.html'>Program</a>
                 </h3>
               </header>
             </article>
@@ -101,7 +101,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/registration.html'>Registration</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/registration.html'>Registration</a>
                 </h3>
               </header>
             </article>
@@ -112,7 +112,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/sponsor.html'>Sponsors</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/sponsor.html'>Sponsors</a> </h3>
               </header>
             </article>
 
@@ -122,7 +122,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/venue.html'>Venue</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/venue.html'>Venue</a> </h3>
               </header>
             </article>
 
@@ -133,7 +133,7 @@
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/cfp.html'>Call for Sessions Proposals</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/cfp.html'>Call for Sessions Proposals</a>
                 </h3>
               </header>
             </article>
@@ -146,7 +146,7 @@
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/committee.html'>Steering committee</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/committee.html'>Steering committee</a>
                 </h3>
               </header>
             </article>
@@ -157,7 +157,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2018' target="_blank">Past US2TS event</a> </h3>
+                <h3 class='list-item-title'> <a href='/2018' target="_blank">Past US2TS event</a> </h3>
               </header>
             </article>
           </div>

--- a/2019/posts/program-session-keynote-helena.html
+++ b/2019/posts/program-session-keynote-helena.html
@@ -15,16 +15,16 @@
     <title>2nd U.S. Semantic Technologies Symposium 2019</title>
   
     <link rel='canonical' href='http://us2ts.org/2019/'>
-    <link rel='icon' href='http://us2ts.org/2019/favicon.ico'>
+    <link rel='icon' href='/2019/favicon.ico'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/main.67a788c9.css">
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/custom.css">
+    <link rel='stylesheet' href="/2019/css/main.67a788c9.css">
+    <link rel='stylesheet' href="/2019/css/custom.css">
   </head>
   
 <body class='home'>
   <div class='site'>
     <header id='header' class='header-container'>
-      <div><a href="http://us2ts.org"><img src="http://us2ts.org/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
+      <div><a href="/"><img src="/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
         U.S. Semantic Technologies Symposium Series <br />
         <div style="font-size: 70%;margin-left:120px;"> <b>March 11-13, 2019</b> at Duke University in Durham, NC</div>
       </div>
@@ -32,20 +32,20 @@
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
           <ul class='main-menu'>
-            <li><a href='http://us2ts.org/2019/' aria-current='page'>Home</a></li>
-            <li><a href='http://us2ts.org/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
-            <li><a href='http://us2ts.org/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
-            <li><a href='http://us2ts.org/2019/posts/registration.html' aria-current='page'>Registration</a></li>
-            <li><a href='http://us2ts.org/2019/posts/venue.html' aria-current='page'>Venue</a></li>
-            <li><a href='http://us2ts.org/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
-            <li><a href='http://us2ts.org/2019/posts/about.html' aria-current='page'>About</a></li>
+            <li><a href='/2019/' aria-current='page'>Home</a></li>
+            <li><a href='/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
+            <li><a href='/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
+            <li><a href='/2019/posts/registration.html' aria-current='page'>Registration</a></li>
+            <li><a href='/2019/posts/venue.html' aria-current='page'>Venue</a></li>
+            <li><a href='/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
+            <li><a href='/2019/posts/about.html' aria-current='page'>About</a></li>
             <li>
               <div class='menu-dropdown' aria-current='page'>Series
                 <ul class="main-menu menu-dropdown-content">
-                  <li><a href='http://us2ts.org/2019/' aria-current='page'>2019</a>
+                  <li><a href='/2019/' aria-current='page'>2019</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
-                  <li> <a href='http://us2ts.org/2018/' aria-current='page'>2018</a>
+                  <li> <a href='/2018/' aria-current='page'>2018</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
                 </ul>
@@ -92,7 +92,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/program.html'>Program</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/program.html'>Program</a>
                 </h3>
               </header>
             </article>
@@ -102,7 +102,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/registration.html'>Registration</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/registration.html'>Registration</a>
                 </h3>
               </header>
             </article>
@@ -113,7 +113,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/sponsor.html'>Sponsors</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/sponsor.html'>Sponsors</a> </h3>
               </header>
             </article>
 
@@ -123,7 +123,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/venue.html'>Venue</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/venue.html'>Venue</a> </h3>
               </header>
             </article>
 
@@ -134,7 +134,7 @@
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/cfp.html'>Call for Sessions Proposals</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/cfp.html'>Call for Sessions Proposals</a>
                 </h3>
               </header>
             </article>
@@ -147,7 +147,7 @@
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/committee.html'>Steering committee</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/committee.html'>Steering committee</a>
                 </h3>
               </header>
             </article>
@@ -158,7 +158,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2018' target="_blank">Past US2TS event</a> </h3>
+                <h3 class='list-item-title'> <a href='/2018' target="_blank">Past US2TS event</a> </h3>
               </header>
             </article>
           </div>

--- a/2019/posts/program-session-lightning-talks.html
+++ b/2019/posts/program-session-lightning-talks.html
@@ -15,16 +15,16 @@
     <title>2nd U.S. Semantic Technologies Symposium 2019</title>
   
     <link rel='canonical' href='http://us2ts.org/2019/'>
-    <link rel='icon' href='http://us2ts.org/2019/favicon.ico'>
+    <link rel='icon' href='/2019/favicon.ico'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/main.67a788c9.css">
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/custom.css">
+    <link rel='stylesheet' href="/2019/css/main.67a788c9.css">
+    <link rel='stylesheet' href="/2019/css/custom.css">
   </head>
   
 <body class='home'>
   <div class='site'>
     <header id='header' class='header-container'>
-      <div><a href="http://us2ts.org"><img src="http://us2ts.org/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
+      <div><a href="/"><img src="/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
         U.S. Semantic Technologies Symposium Series <br />
         <div style="font-size: 70%;margin-left:120px;"> <b>March 11-13, 2019</b> at Duke University in Durham, NC</div>
       </div>
@@ -32,20 +32,20 @@
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
           <ul class='main-menu'>
-            <li><a href='http://us2ts.org/2019/' aria-current='page'>Home</a></li>
-            <li><a href='http://us2ts.org/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
-            <li><a href='http://us2ts.org/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
-            <li><a href='http://us2ts.org/2019/posts/registration.html' aria-current='page'>Registration</a></li>
-            <li><a href='http://us2ts.org/2019/posts/venue.html' aria-current='page'>Venue</a></li>
-            <li><a href='http://us2ts.org/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
-            <li><a href='http://us2ts.org/2019/posts/about.html' aria-current='page'>About</a></li>
+            <li><a href='/2019/' aria-current='page'>Home</a></li>
+            <li><a href='/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
+            <li><a href='/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
+            <li><a href='/2019/posts/registration.html' aria-current='page'>Registration</a></li>
+            <li><a href='/2019/posts/venue.html' aria-current='page'>Venue</a></li>
+            <li><a href='/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
+            <li><a href='/2019/posts/about.html' aria-current='page'>About</a></li>
             <li>
               <div class='menu-dropdown' aria-current='page'>Series
                 <ul class="main-menu menu-dropdown-content">
-                  <li><a href='http://us2ts.org/2019/' aria-current='page'>2019</a>
+                  <li><a href='/2019/' aria-current='page'>2019</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
-                  <li> <a href='http://us2ts.org/2018/' aria-current='page'>2018</a>
+                  <li> <a href='/2018/' aria-current='page'>2018</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
                 </ul>
@@ -136,7 +136,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/program.html'>Program</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/program.html'>Program</a>
                 </h3>
               </header>
             </article>
@@ -146,7 +146,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/registration.html'>Registration</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/registration.html'>Registration</a>
                 </h3>
               </header>
             </article>
@@ -157,7 +157,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/sponsor.html'>Sponsors</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/sponsor.html'>Sponsors</a> </h3>
               </header>
             </article>
 
@@ -167,7 +167,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/venue.html'>Venue</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/venue.html'>Venue</a> </h3>
               </header>
             </article>
 
@@ -178,7 +178,7 @@
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/cfp.html'>Call for Sessions Proposals</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/cfp.html'>Call for Sessions Proposals</a>
                 </h3>
               </header>
             </article>
@@ -191,7 +191,7 @@
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/committee.html'>Steering committee</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/committee.html'>Steering committee</a>
                 </h3>
               </header>
             </article>
@@ -202,7 +202,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2018' target="_blank">Past US2TS event</a> </h3>
+                <h3 class='list-item-title'> <a href='/2018' target="_blank">Past US2TS event</a> </h3>
               </header>
             </article>
           </div>

--- a/2019/posts/program-session-posters.html
+++ b/2019/posts/program-session-posters.html
@@ -15,16 +15,16 @@
     <title>2nd U.S. Semantic Technologies Symposium 2019</title>
   
     <link rel='canonical' href='http://us2ts.org/2019/'>
-    <link rel='icon' href='http://us2ts.org/2019/favicon.ico'>
+    <link rel='icon' href='/2019/favicon.ico'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/main.67a788c9.css">
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/custom.css">
+    <link rel='stylesheet' href="/2019/css/main.67a788c9.css">
+    <link rel='stylesheet' href="/2019/css/custom.css">
   </head>
   
 <body class='home'>
   <div class='site'>
     <header id='header' class='header-container'>
-      <div><a href="http://us2ts.org"><img src="http://us2ts.org/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
+      <div><a href="/"><img src="/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
         U.S. Semantic Technologies Symposium Series <br />
         <div style="font-size: 70%;margin-left:120px;"> <b>March 11-13, 2019</b> at Duke University in Durham, NC</div>
       </div>
@@ -32,20 +32,20 @@
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
           <ul class='main-menu'>
-            <li><a href='http://us2ts.org/2019/' aria-current='page'>Home</a></li>
-            <li><a href='http://us2ts.org/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
-            <li><a href='http://us2ts.org/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
-            <li><a href='http://us2ts.org/2019/posts/registration.html' aria-current='page'>Registration</a></li>
-            <li><a href='http://us2ts.org/2019/posts/venue.html' aria-current='page'>Venue</a></li>
-            <li><a href='http://us2ts.org/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
-            <li><a href='http://us2ts.org/2019/posts/about.html' aria-current='page'>About</a></li>
+            <li><a href='/2019/' aria-current='page'>Home</a></li>
+            <li><a href='/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
+            <li><a href='/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
+            <li><a href='/2019/posts/registration.html' aria-current='page'>Registration</a></li>
+            <li><a href='/2019/posts/venue.html' aria-current='page'>Venue</a></li>
+            <li><a href='/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
+            <li><a href='/2019/posts/about.html' aria-current='page'>About</a></li>
             <li>
               <div class='menu-dropdown' aria-current='page'>Series
                 <ul class="main-menu menu-dropdown-content">
-                  <li><a href='http://us2ts.org/2019/' aria-current='page'>2019</a>
+                  <li><a href='/2019/' aria-current='page'>2019</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
-                  <li> <a href='http://us2ts.org/2018/' aria-current='page'>2018</a>
+                  <li> <a href='/2018/' aria-current='page'>2018</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
                 </ul>
@@ -136,7 +136,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/program.html'>Program</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/program.html'>Program</a>
                 </h3>
               </header>
             </article>
@@ -146,7 +146,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/registration.html'>Registration</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/registration.html'>Registration</a>
                 </h3>
               </header>
             </article>
@@ -157,7 +157,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/sponsor.html'>Sponsors</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/sponsor.html'>Sponsors</a> </h3>
               </header>
             </article>
 
@@ -167,7 +167,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/venue.html'>Venue</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/venue.html'>Venue</a> </h3>
               </header>
             </article>
 
@@ -178,7 +178,7 @@
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/cfp.html'>Call for Sessions Proposals</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/cfp.html'>Call for Sessions Proposals</a>
                 </h3>
               </header>
             </article>
@@ -191,7 +191,7 @@
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/committee.html'>Steering committee</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/committee.html'>Steering committee</a>
                 </h3>
               </header>
             </article>
@@ -202,7 +202,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2018' target="_blank">Past US2TS event</a> </h3>
+                <h3 class='list-item-title'> <a href='/2018' target="_blank">Past US2TS event</a> </h3>
               </header>
             </article>
           </div>

--- a/2019/posts/program-session-v.html
+++ b/2019/posts/program-session-v.html
@@ -15,16 +15,16 @@
     <title>2nd U.S. Semantic Technologies Symposium 2019</title>
   
     <link rel='canonical' href='http://us2ts.org/2019/'>
-    <link rel='icon' href='http://us2ts.org/2019/favicon.ico'>
+    <link rel='icon' href='/2019/favicon.ico'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/main.67a788c9.css">
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/custom.css">
+    <link rel='stylesheet' href="/2019/css/main.67a788c9.css">
+    <link rel='stylesheet' href="/2019/css/custom.css">
   </head>
   
 <body class='home'>
   <div class='site'>
     <header id='header' class='header-container'>
-      <div><a href="http://us2ts.org"><img src="http://us2ts.org/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
+      <div><a href="/"><img src="/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
         U.S. Semantic Technologies Symposium Series <br />
         <div style="font-size: 70%;margin-left:120px;"> <b>March 11-13, 2019</b> at Duke University in Durham, NC</div>
       </div>
@@ -32,20 +32,20 @@
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
           <ul class='main-menu'>
-            <li><a href='http://us2ts.org/2019/' aria-current='page'>Home</a></li>
-            <li><a href='http://us2ts.org/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
-            <li><a href='http://us2ts.org/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
-            <li><a href='http://us2ts.org/2019/posts/registration.html' aria-current='page'>Registration</a></li>
-            <li><a href='http://us2ts.org/2019/posts/venue.html' aria-current='page'>Venue</a></li>
-            <li><a href='http://us2ts.org/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
-            <li><a href='http://us2ts.org/2019/posts/about.html' aria-current='page'>About</a></li>
+            <li><a href='/2019/' aria-current='page'>Home</a></li>
+            <li><a href='/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
+            <li><a href='/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
+            <li><a href='/2019/posts/registration.html' aria-current='page'>Registration</a></li>
+            <li><a href='/2019/posts/venue.html' aria-current='page'>Venue</a></li>
+            <li><a href='/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
+            <li><a href='/2019/posts/about.html' aria-current='page'>About</a></li>
             <li>
               <div class='menu-dropdown' aria-current='page'>Series
                 <ul class="main-menu menu-dropdown-content">
-                  <li><a href='http://us2ts.org/2019/' aria-current='page'>2019</a>
+                  <li><a href='/2019/' aria-current='page'>2019</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
-                  <li> <a href='http://us2ts.org/2018/' aria-current='page'>2018</a>
+                  <li> <a href='/2018/' aria-current='page'>2018</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
                 </ul>
@@ -122,7 +122,7 @@ This breakout-session aims at exposing existing solutions towards  injecting  st
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/program.html'>Program</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/program.html'>Program</a>
                 </h3>
               </header>
             </article>
@@ -132,7 +132,7 @@ This breakout-session aims at exposing existing solutions towards  injecting  st
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/registration.html'>Registration</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/registration.html'>Registration</a>
                 </h3>
               </header>
             </article>
@@ -143,7 +143,7 @@ This breakout-session aims at exposing existing solutions towards  injecting  st
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/sponsor.html'>Sponsors</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/sponsor.html'>Sponsors</a> </h3>
               </header>
             </article>
 
@@ -153,7 +153,7 @@ This breakout-session aims at exposing existing solutions towards  injecting  st
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/venue.html'>Venue</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/venue.html'>Venue</a> </h3>
               </header>
             </article>
 
@@ -164,7 +164,7 @@ This breakout-session aims at exposing existing solutions towards  injecting  st
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/cfp.html'>Call for Sessions Proposals</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/cfp.html'>Call for Sessions Proposals</a>
                 </h3>
               </header>
             </article>
@@ -177,7 +177,7 @@ This breakout-session aims at exposing existing solutions towards  injecting  st
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/committee.html'>Steering committee</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/committee.html'>Steering committee</a>
                 </h3>
               </header>
             </article>
@@ -188,7 +188,7 @@ This breakout-session aims at exposing existing solutions towards  injecting  st
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2018' target="_blank">Past US2TS event</a> </h3>
+                <h3 class='list-item-title'> <a href='/2018' target="_blank">Past US2TS event</a> </h3>
               </header>
             </article>
           </div>

--- a/2019/posts/program-session-vi.html
+++ b/2019/posts/program-session-vi.html
@@ -15,16 +15,16 @@
     <title>2nd U.S. Semantic Technologies Symposium 2019</title>
   
     <link rel='canonical' href='http://us2ts.org/2019/'>
-    <link rel='icon' href='http://us2ts.org/2019/favicon.ico'>
+    <link rel='icon' href='/2019/favicon.ico'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/main.67a788c9.css">
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/custom.css">
+    <link rel='stylesheet' href="/2019/css/main.67a788c9.css">
+    <link rel='stylesheet' href="/2019/css/custom.css">
   </head>
   
 <body class='home'>
   <div class='site'>
     <header id='header' class='header-container'>
-      <div><a href="http://us2ts.org"><img src="http://us2ts.org/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
+      <div><a href="/"><img src="/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
         U.S. Semantic Technologies Symposium Series <br />
         <div style="font-size: 70%;margin-left:120px;"> <b>March 11-13, 2019</b> at Duke University in Durham, NC</div>
       </div>
@@ -32,20 +32,20 @@
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
           <ul class='main-menu'>
-            <li><a href='http://us2ts.org/2019/' aria-current='page'>Home</a></li>
-            <li><a href='http://us2ts.org/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
-            <li><a href='http://us2ts.org/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
-            <li><a href='http://us2ts.org/2019/posts/registration.html' aria-current='page'>Registration</a></li>
-            <li><a href='http://us2ts.org/2019/posts/venue.html' aria-current='page'>Venue</a></li>
-            <li><a href='http://us2ts.org/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
-            <li><a href='http://us2ts.org/2019/posts/about.html' aria-current='page'>About</a></li>
+            <li><a href='/2019/' aria-current='page'>Home</a></li>
+            <li><a href='/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
+            <li><a href='/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
+            <li><a href='/2019/posts/registration.html' aria-current='page'>Registration</a></li>
+            <li><a href='/2019/posts/venue.html' aria-current='page'>Venue</a></li>
+            <li><a href='/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
+            <li><a href='/2019/posts/about.html' aria-current='page'>About</a></li>
             <li>
               <div class='menu-dropdown' aria-current='page'>Series
                 <ul class="main-menu menu-dropdown-content">
-                  <li><a href='http://us2ts.org/2019/' aria-current='page'>2019</a>
+                  <li><a href='/2019/' aria-current='page'>2019</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
-                  <li> <a href='http://us2ts.org/2018/' aria-current='page'>2018</a>
+                  <li> <a href='/2018/' aria-current='page'>2018</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
                 </ul>
@@ -163,7 +163,7 @@ During this talk, we will see how the ontology has been built automatically from
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/program.html'>Program</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/program.html'>Program</a>
                 </h3>
               </header>
             </article>
@@ -173,7 +173,7 @@ During this talk, we will see how the ontology has been built automatically from
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/registration.html'>Registration</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/registration.html'>Registration</a>
                 </h3>
               </header>
             </article>
@@ -184,7 +184,7 @@ During this talk, we will see how the ontology has been built automatically from
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/sponsor.html'>Sponsors</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/sponsor.html'>Sponsors</a> </h3>
               </header>
             </article>
 
@@ -194,7 +194,7 @@ During this talk, we will see how the ontology has been built automatically from
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/venue.html'>Venue</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/venue.html'>Venue</a> </h3>
               </header>
             </article>
 
@@ -205,7 +205,7 @@ During this talk, we will see how the ontology has been built automatically from
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/cfp.html'>Call for Sessions Proposals</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/cfp.html'>Call for Sessions Proposals</a>
                 </h3>
               </header>
             </article>
@@ -218,7 +218,7 @@ During this talk, we will see how the ontology has been built automatically from
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/committee.html'>Steering committee</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/committee.html'>Steering committee</a>
                 </h3>
               </header>
             </article>
@@ -229,7 +229,7 @@ During this talk, we will see how the ontology has been built automatically from
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2018' target="_blank">Past US2TS event</a> </h3>
+                <h3 class='list-item-title'> <a href='/2018' target="_blank">Past US2TS event</a> </h3>
               </header>
             </article>
           </div>

--- a/2019/posts/program-session-vii.html
+++ b/2019/posts/program-session-vii.html
@@ -15,16 +15,16 @@
     <title>2nd U.S. Semantic Technologies Symposium 2019</title>
   
     <link rel='canonical' href='http://us2ts.org/2019/'>
-    <link rel='icon' href='http://us2ts.org/2019/favicon.ico'>
+    <link rel='icon' href='/2019/favicon.ico'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/main.67a788c9.css">
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/custom.css">
+    <link rel='stylesheet' href="/2019/css/main.67a788c9.css">
+    <link rel='stylesheet' href="/2019/css/custom.css">
   </head>
   
 <body class='home'>
   <div class='site'>
     <header id='header' class='header-container'>
-      <div><a href="http://us2ts.org"><img src="http://us2ts.org/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
+      <div><a href="/"><img src="/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
         U.S. Semantic Technologies Symposium Series <br />
         <div style="font-size: 70%;margin-left:120px;"> <b>March 11-13, 2019</b> at Duke University in Durham, NC</div>
       </div>
@@ -32,20 +32,20 @@
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
           <ul class='main-menu'>
-            <li><a href='http://us2ts.org/2019/' aria-current='page'>Home</a></li>
-            <li><a href='http://us2ts.org/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
-            <li><a href='http://us2ts.org/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
-            <li><a href='http://us2ts.org/2019/posts/registration.html' aria-current='page'>Registration</a></li>
-            <li><a href='http://us2ts.org/2019/posts/venue.html' aria-current='page'>Venue</a></li>
-            <li><a href='http://us2ts.org/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
-            <li><a href='http://us2ts.org/2019/posts/about.html' aria-current='page'>About</a></li>
+            <li><a href='/2019/' aria-current='page'>Home</a></li>
+            <li><a href='/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
+            <li><a href='/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
+            <li><a href='/2019/posts/registration.html' aria-current='page'>Registration</a></li>
+            <li><a href='/2019/posts/venue.html' aria-current='page'>Venue</a></li>
+            <li><a href='/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
+            <li><a href='/2019/posts/about.html' aria-current='page'>About</a></li>
             <li>
               <div class='menu-dropdown' aria-current='page'>Series
                 <ul class="main-menu menu-dropdown-content">
-                  <li><a href='http://us2ts.org/2019/' aria-current='page'>2019</a>
+                  <li><a href='/2019/' aria-current='page'>2019</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
-                  <li> <a href='http://us2ts.org/2018/' aria-current='page'>2018</a>
+                  <li> <a href='/2018/' aria-current='page'>2018</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
                 </ul>
@@ -98,7 +98,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/program.html'>Program</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/program.html'>Program</a>
                 </h3>
               </header>
             </article>
@@ -108,7 +108,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/registration.html'>Registration</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/registration.html'>Registration</a>
                 </h3>
               </header>
             </article>
@@ -119,7 +119,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/sponsor.html'>Sponsors</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/sponsor.html'>Sponsors</a> </h3>
               </header>
             </article>
 
@@ -129,7 +129,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/venue.html'>Venue</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/venue.html'>Venue</a> </h3>
               </header>
             </article>
 
@@ -140,7 +140,7 @@
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/cfp.html'>Call for Sessions Proposals</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/cfp.html'>Call for Sessions Proposals</a>
                 </h3>
               </header>
             </article>
@@ -153,7 +153,7 @@
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/committee.html'>Steering committee</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/committee.html'>Steering committee</a>
                 </h3>
               </header>
             </article>
@@ -164,7 +164,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2018' target="_blank">Past US2TS event</a> </h3>
+                <h3 class='list-item-title'> <a href='/2018' target="_blank">Past US2TS event</a> </h3>
               </header>
             </article>
           </div>

--- a/2019/posts/program-session-viii.html
+++ b/2019/posts/program-session-viii.html
@@ -15,16 +15,16 @@
     <title>2nd U.S. Semantic Technologies Symposium 2019</title>
   
     <link rel='canonical' href='http://us2ts.org/2019/'>
-    <link rel='icon' href='http://us2ts.org/2019/favicon.ico'>
+    <link rel='icon' href='/2019/favicon.ico'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/main.67a788c9.css">
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/custom.css">
+    <link rel='stylesheet' href="/2019/css/main.67a788c9.css">
+    <link rel='stylesheet' href="/2019/css/custom.css">
   </head>
   
 <body class='home'>
   <div class='site'>
     <header id='header' class='header-container'>
-      <div><a href="http://us2ts.org"><img src="http://us2ts.org/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
+      <div><a href="/"><img src="/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
         U.S. Semantic Technologies Symposium Series <br />
         <div style="font-size: 70%;margin-left:120px;"> <b>March 11-13, 2019</b> at Duke University in Durham, NC</div>
       </div>
@@ -32,20 +32,20 @@
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
           <ul class='main-menu'>
-            <li><a href='http://us2ts.org/2019/' aria-current='page'>Home</a></li>
-            <li><a href='http://us2ts.org/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
-            <li><a href='http://us2ts.org/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
-            <li><a href='http://us2ts.org/2019/posts/registration.html' aria-current='page'>Registration</a></li>
-            <li><a href='http://us2ts.org/2019/posts/venue.html' aria-current='page'>Venue</a></li>
-            <li><a href='http://us2ts.org/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
-            <li><a href='http://us2ts.org/2019/posts/about.html' aria-current='page'>About</a></li>
+            <li><a href='/2019/' aria-current='page'>Home</a></li>
+            <li><a href='/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
+            <li><a href='/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
+            <li><a href='/2019/posts/registration.html' aria-current='page'>Registration</a></li>
+            <li><a href='/2019/posts/venue.html' aria-current='page'>Venue</a></li>
+            <li><a href='/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
+            <li><a href='/2019/posts/about.html' aria-current='page'>About</a></li>
             <li>
               <div class='menu-dropdown' aria-current='page'>Series
                 <ul class="main-menu menu-dropdown-content">
-                  <li><a href='http://us2ts.org/2019/' aria-current='page'>2019</a>
+                  <li><a href='/2019/' aria-current='page'>2019</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
-                  <li> <a href='http://us2ts.org/2018/' aria-current='page'>2018</a>
+                  <li> <a href='/2018/' aria-current='page'>2018</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
                 </ul>
@@ -118,7 +118,7 @@ We will conclude with a QA session where we will go reflect on the raised issues
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/program.html'>Program</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/program.html'>Program</a>
                 </h3>
               </header>
             </article>
@@ -128,7 +128,7 @@ We will conclude with a QA session where we will go reflect on the raised issues
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/registration.html'>Registration</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/registration.html'>Registration</a>
                 </h3>
               </header>
             </article>
@@ -139,7 +139,7 @@ We will conclude with a QA session where we will go reflect on the raised issues
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/sponsor.html'>Sponsors</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/sponsor.html'>Sponsors</a> </h3>
               </header>
             </article>
 
@@ -149,7 +149,7 @@ We will conclude with a QA session where we will go reflect on the raised issues
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/venue.html'>Venue</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/venue.html'>Venue</a> </h3>
               </header>
             </article>
 
@@ -160,7 +160,7 @@ We will conclude with a QA session where we will go reflect on the raised issues
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/cfp.html'>Call for Sessions Proposals</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/cfp.html'>Call for Sessions Proposals</a>
                 </h3>
               </header>
             </article>
@@ -173,7 +173,7 @@ We will conclude with a QA session where we will go reflect on the raised issues
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/committee.html'>Steering committee</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/committee.html'>Steering committee</a>
                 </h3>
               </header>
             </article>
@@ -184,7 +184,7 @@ We will conclude with a QA session where we will go reflect on the raised issues
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2018' target="_blank">Past US2TS event</a> </h3>
+                <h3 class='list-item-title'> <a href='/2018' target="_blank">Past US2TS event</a> </h3>
               </header>
             </article>
           </div>

--- a/2019/posts/program-session-x.html
+++ b/2019/posts/program-session-x.html
@@ -15,16 +15,16 @@
     <title>2nd U.S. Semantic Technologies Symposium 2019</title>
   
     <link rel='canonical' href='http://us2ts.org/2019/'>
-    <link rel='icon' href='http://us2ts.org/2019/favicon.ico'>
+    <link rel='icon' href='/2019/favicon.ico'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/main.67a788c9.css">
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/custom.css">
+    <link rel='stylesheet' href="/2019/css/main.67a788c9.css">
+    <link rel='stylesheet' href="/2019/css/custom.css">
   </head>
   
 <body class='home'>
   <div class='site'>
     <header id='header' class='header-container'>
-      <div><a href="http://us2ts.org"><img src="http://us2ts.org/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
+      <div><a href="/"><img src="/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
         U.S. Semantic Technologies Symposium Series <br />
         <div style="font-size: 70%;margin-left:120px;"> <b>March 11-13, 2019</b> at Duke University in Durham, NC</div>
       </div>
@@ -32,20 +32,20 @@
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
           <ul class='main-menu'>
-            <li><a href='http://us2ts.org/2019/' aria-current='page'>Home</a></li>
-            <li><a href='http://us2ts.org/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
-            <li><a href='http://us2ts.org/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
-            <li><a href='http://us2ts.org/2019/posts/registration.html' aria-current='page'>Registration</a></li>
-            <li><a href='http://us2ts.org/2019/posts/venue.html' aria-current='page'>Venue</a></li>
-            <li><a href='http://us2ts.org/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
-            <li><a href='http://us2ts.org/2019/posts/about.html' aria-current='page'>About</a></li>
+            <li><a href='/2019/' aria-current='page'>Home</a></li>
+            <li><a href='/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
+            <li><a href='/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
+            <li><a href='/2019/posts/registration.html' aria-current='page'>Registration</a></li>
+            <li><a href='/2019/posts/venue.html' aria-current='page'>Venue</a></li>
+            <li><a href='/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
+            <li><a href='/2019/posts/about.html' aria-current='page'>About</a></li>
             <li>
               <div class='menu-dropdown' aria-current='page'>Series
                 <ul class="main-menu menu-dropdown-content">
-                  <li><a href='http://us2ts.org/2019/' aria-current='page'>2019</a>
+                  <li><a href='/2019/' aria-current='page'>2019</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
-                  <li> <a href='http://us2ts.org/2018/' aria-current='page'>2018</a>
+                  <li> <a href='/2018/' aria-current='page'>2018</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
                 </ul>
@@ -138,7 +138,7 @@ This is an interactive session.  We will further collect, document and rank issu
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/program.html'>Program</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/program.html'>Program</a>
                 </h3>
               </header>
             </article>
@@ -148,7 +148,7 @@ This is an interactive session.  We will further collect, document and rank issu
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/registration.html'>Registration</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/registration.html'>Registration</a>
                 </h3>
               </header>
             </article>
@@ -159,7 +159,7 @@ This is an interactive session.  We will further collect, document and rank issu
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/sponsor.html'>Sponsors</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/sponsor.html'>Sponsors</a> </h3>
               </header>
             </article>
 
@@ -169,7 +169,7 @@ This is an interactive session.  We will further collect, document and rank issu
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/venue.html'>Venue</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/venue.html'>Venue</a> </h3>
               </header>
             </article>
 
@@ -180,7 +180,7 @@ This is an interactive session.  We will further collect, document and rank issu
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/cfp.html'>Call for Sessions Proposals</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/cfp.html'>Call for Sessions Proposals</a>
                 </h3>
               </header>
             </article>
@@ -193,7 +193,7 @@ This is an interactive session.  We will further collect, document and rank issu
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/committee.html'>Steering committee</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/committee.html'>Steering committee</a>
                 </h3>
               </header>
             </article>
@@ -204,7 +204,7 @@ This is an interactive session.  We will further collect, document and rank issu
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2018' target="_blank">Past US2TS event</a> </h3>
+                <h3 class='list-item-title'> <a href='/2018' target="_blank">Past US2TS event</a> </h3>
               </header>
             </article>
           </div>

--- a/2019/posts/program-session-xi.html
+++ b/2019/posts/program-session-xi.html
@@ -15,16 +15,16 @@
     <title>2nd U.S. Semantic Technologies Symposium 2019</title>
   
     <link rel='canonical' href='http://us2ts.org/2019/'>
-    <link rel='icon' href='http://us2ts.org/2019/favicon.ico'>
+    <link rel='icon' href='/2019/favicon.ico'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/main.67a788c9.css">
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/custom.css">
+    <link rel='stylesheet' href="/2019/css/main.67a788c9.css">
+    <link rel='stylesheet' href="/2019/css/custom.css">
   </head>
   
 <body class='home'>
   <div class='site'>
     <header id='header' class='header-container'>
-      <div><a href="http://us2ts.org"><img src="http://us2ts.org/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
+      <div><a href="/"><img src="/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
         U.S. Semantic Technologies Symposium Series <br />
         <div style="font-size: 70%;margin-left:120px;"> <b>March 11-13, 2019</b> at Duke University in Durham, NC</div>
       </div>
@@ -32,20 +32,20 @@
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
           <ul class='main-menu'>
-            <li><a href='http://us2ts.org/2019/' aria-current='page'>Home</a></li>
-            <li><a href='http://us2ts.org/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
-            <li><a href='http://us2ts.org/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
-            <li><a href='http://us2ts.org/2019/posts/registration.html' aria-current='page'>Registration</a></li>
-            <li><a href='http://us2ts.org/2019/posts/venue.html' aria-current='page'>Venue</a></li>
-            <li><a href='http://us2ts.org/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
-            <li><a href='http://us2ts.org/2019/posts/about.html' aria-current='page'>About</a></li>
+            <li><a href='/2019/' aria-current='page'>Home</a></li>
+            <li><a href='/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
+            <li><a href='/2019/posts/program.html'  class='current' aria-current='page'>Program</a></li>
+            <li><a href='/2019/posts/registration.html' aria-current='page'>Registration</a></li>
+            <li><a href='/2019/posts/venue.html' aria-current='page'>Venue</a></li>
+            <li><a href='/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
+            <li><a href='/2019/posts/about.html' aria-current='page'>About</a></li>
             <li>
               <div class='menu-dropdown' aria-current='page'>Series
                 <ul class="main-menu menu-dropdown-content">
-                  <li><a href='http://us2ts.org/2019/' aria-current='page'>2019</a>
+                  <li><a href='/2019/' aria-current='page'>2019</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
-                  <li> <a href='http://us2ts.org/2018/' aria-current='page'>2018</a>
+                  <li> <a href='/2018/' aria-current='page'>2018</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
                 </ul>
@@ -102,7 +102,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/program.html'>Program</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/program.html'>Program</a>
                 </h3>
               </header>
             </article>
@@ -112,7 +112,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/registration.html'>Registration</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/registration.html'>Registration</a>
                 </h3>
               </header>
             </article>
@@ -123,7 +123,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/sponsor.html'>Sponsors</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/sponsor.html'>Sponsors</a> </h3>
               </header>
             </article>
 
@@ -133,7 +133,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/venue.html'>Venue</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/venue.html'>Venue</a> </h3>
               </header>
             </article>
 
@@ -144,7 +144,7 @@
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/cfp.html'>Call for Sessions Proposals</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/cfp.html'>Call for Sessions Proposals</a>
                 </h3>
               </header>
             </article>
@@ -157,7 +157,7 @@
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/committee.html'>Steering committee</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/committee.html'>Steering committee</a>
                 </h3>
               </header>
             </article>
@@ -168,7 +168,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2018' target="_blank">Past US2TS event</a> </h3>
+                <h3 class='list-item-title'> <a href='/2018' target="_blank">Past US2TS event</a> </h3>
               </header>
             </article>
           </div>

--- a/2019/posts/program.html
+++ b/2019/posts/program.html
@@ -15,17 +15,17 @@
   <title>2nd U.S. Semantic Technologies Symposium 2019</title>
 
   <link rel='canonical' href='http://us2ts.org/2019/'>
-  <link rel='icon' href='http://us2ts.org/2019/favicon.ico'>
+  <link rel='icon' href='/2019/favicon.ico'>
   <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-  <link rel='stylesheet' href="http://us2ts.org/2019/css/main.67a788c9.css">
-  <link rel='stylesheet' href="http://us2ts.org/2019/css/custom.css">
+  <link rel='stylesheet' href="/2019/css/main.67a788c9.css">
+  <link rel='stylesheet' href="/2019/css/custom.css">
 </head>
 
 
 <body class='section'>
   <div class='site'>
     <header id='header' class='header-container'>
-      <div><a href="http://us2ts.org"><img src="http://us2ts.org/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
+      <div><a href="/"><img src="/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
         U.S. Semantic Technologies Symposium Series <br />
         <div style="font-size: 70%;margin-left:120px;"> <b>March 11-13, 2019</b> at Duke University in Durham, NC</div>
       </div>
@@ -33,20 +33,20 @@
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
           <ul class='main-menu'>
-            <li><a href='http://us2ts.org/2019/'  aria-current='page'>Home</a></li>
-            <li><a href='http://us2ts.org/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
-            <li><a href='http://us2ts.org/2019/posts/program.html' class='current' aria-current='page'>Program</a></li>
-            <li><a href='http://us2ts.org/2019/posts/registration.html' aria-current='page'>Registration</a></li>            
-            <li><a href='http://us2ts.org/2019/posts/venue.html' aria-current='page'>Venue</a></li>            
-            <li><a href='http://us2ts.org/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
-            <li><a href='http://us2ts.org/2019/posts/about.html'  aria-current='page'>About</a></li>
+            <li><a href='/2019/'  aria-current='page'>Home</a></li>
+            <li><a href='/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
+            <li><a href='/2019/posts/program.html' class='current' aria-current='page'>Program</a></li>
+            <li><a href='/2019/posts/registration.html' aria-current='page'>Registration</a></li>            
+            <li><a href='/2019/posts/venue.html' aria-current='page'>Venue</a></li>            
+            <li><a href='/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
+            <li><a href='/2019/posts/about.html'  aria-current='page'>About</a></li>
             <li>
               <div class='menu-dropdown' aria-current='page'>Series
                 <ul class="main-menu menu-dropdown-content">
-                  <li><a href='http://us2ts.org/2019/' aria-current='page'>2019</a>
+                  <li><a href='/2019/' aria-current='page'>2019</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
-                  <li> <a href='http://us2ts.org/2018/' aria-current='page'>2018</a>
+                  <li> <a href='/2018/' aria-current='page'>2018</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
                 </ul>
@@ -89,12 +89,12 @@
           
 		  <p> <strong> Keynote Speakers </strong>
 			<div style="float:left; padding:10x">
-       <img src="http://www.us2ts.org/2019/us2ts-2019-keynote-speaker-deborah.png" width="200px"/> <br/> 
+       <img src="/2019/us2ts-2019-keynote-speaker-deborah.png" width="200px"/> <br/> 
        <a href="https://tw.rpi.edu/web/person/deborah_l_mcguinness"> Deborah McGuinness</a> <br/> Professor, Rensselaer Polytechnic Institute <br/>
 	   <a href="program-session-keynote-deborah.html">Keynote Abstract</a></p>
        
 		   </div>
-		   <div style="float:right; padding:10x"><img src="http://www.us2ts.org/2019/us2ts-2019-keynote-helena.jpg" width="200px"/> <br/>
+		   <div style="float:right; padding:10x"><img src="/2019/us2ts-2019-keynote-helena.jpg" width="200px"/> <br/>
 		   <a href="https://www.linkedin.com/in/helenadeus/" target="_blank">Helena Deus </a> <br/>Technology Research Director, Elsevier 
 		   <br/>
 		   <a href="program-session-keynote-helena.html">Keynote Abstract </a>
@@ -282,7 +282,7 @@ Here are Google Maps links for getting from Penn Pavilion to The Cookery:
                   </span>
                 </div>
                 <header class='list-item-header'>
-                  <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/program.html'>Program</a>
+                  <h3 class='list-item-title'> <a href='/2019/posts/program.html'>Program</a>
                   </h3>
                 </header>
               </article>
@@ -292,7 +292,7 @@ Here are Google Maps links for getting from Penn Pavilion to The Cookery:
                   </span>
                 </div>
                 <header class='list-item-header'>
-                  <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/registration.html'>Registration</a>
+                  <h3 class='list-item-title'> <a href='/2019/posts/registration.html'>Registration</a>
                   </h3>
                 </header>
               </article>
@@ -303,7 +303,7 @@ Here are Google Maps links for getting from Penn Pavilion to The Cookery:
                   </span>
                 </div>
                 <header class='list-item-header'>
-                  <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/sponsor.html'>Sponsors</a> </h3>
+                  <h3 class='list-item-title'> <a href='/2019/posts/sponsor.html'>Sponsors</a> </h3>
                 </header>
               </article>
   
@@ -313,7 +313,7 @@ Here are Google Maps links for getting from Penn Pavilion to The Cookery:
                   </span>
                 </div>
                 <header class='list-item-header'>
-                  <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/venue.html'>Venue</a> </h3>
+                  <h3 class='list-item-title'> <a href='/2019/posts/venue.html'>Venue</a> </h3>
                 </header>
               </article>
   
@@ -324,7 +324,7 @@ Here are Google Maps links for getting from Penn Pavilion to The Cookery:
   
                 </div>
                 <header class='list-item-header'>
-                  <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/cfp.html'>Call for Sessions Proposals</a>
+                  <h3 class='list-item-title'> <a href='/2019/posts/cfp.html'>Call for Sessions Proposals</a>
                   </h3>
                 </header>
               </article>
@@ -337,7 +337,7 @@ Here are Google Maps links for getting from Penn Pavilion to The Cookery:
   
                 </div>
                 <header class='list-item-header'>
-                  <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/committee.html'>Steering committee</a>
+                  <h3 class='list-item-title'> <a href='/2019/posts/committee.html'>Steering committee</a>
                   </h3>
                 </header>
               </article>
@@ -348,7 +348,7 @@ Here are Google Maps links for getting from Penn Pavilion to The Cookery:
                   </span>
                 </div>
                 <header class='list-item-header'>
-                  <h3 class='list-item-title'> <a href='http://us2ts.org/2018' target="_blank">Past US2TS event</a> </h3>
+                  <h3 class='list-item-title'> <a href='/2018' target="_blank">Past US2TS event</a> </h3>
                 </header>
               </article>
             </div>

--- a/2019/posts/registration.html
+++ b/2019/posts/registration.html
@@ -15,16 +15,16 @@
     <title>2nd U.S. Semantic Technologies Symposium 2019</title>
   
     <link rel='canonical' href='http://us2ts.org/2019/'>
-    <link rel='icon' href='http://us2ts.org/2019/favicon.ico'>
+    <link rel='icon' href='/2019/favicon.ico'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/main.67a788c9.css">
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/custom.css">
+    <link rel='stylesheet' href="/2019/css/main.67a788c9.css">
+    <link rel='stylesheet' href="/2019/css/custom.css">
   </head>
   
 <body class='home'>
   <div class='site'>
     <header id='header' class='header-container'>
-      <div><a href="http://us2ts.org"><img src="http://us2ts.org/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
+      <div><a href="/"><img src="/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
         U.S. Semantic Technologies Symposium Series <br />
         <div style="font-size: 70%;margin-left:120px;"> <b>March 11-13, 2019</b> at Duke University in Durham, NC</div>
       </div>
@@ -32,20 +32,20 @@
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
           <ul class='main-menu'>
-            <li><a href='http://us2ts.org/2019/' aria-current='page'>Home</a></li>
-            <li><a href='http://us2ts.org/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
-            <li><a href='http://us2ts.org/2019/posts/program.html' aria-current='page'>Program</a></li>
-            <li><a href='http://us2ts.org/2019/posts/registration.html' class='current' aria-current='page'>Registration</a></li>
-            <li><a href='http://us2ts.org/2019/posts/venue.html' aria-current='page'>Venue</a></li>
-            <li><a href='http://us2ts.org/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
-            <li><a href='http://us2ts.org/2019/posts/about.html' aria-current='page'>About</a></li>
+            <li><a href='/2019/' aria-current='page'>Home</a></li>
+            <li><a href='/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
+            <li><a href='/2019/posts/program.html' aria-current='page'>Program</a></li>
+            <li><a href='/2019/posts/registration.html' class='current' aria-current='page'>Registration</a></li>
+            <li><a href='/2019/posts/venue.html' aria-current='page'>Venue</a></li>
+            <li><a href='/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
+            <li><a href='/2019/posts/about.html' aria-current='page'>About</a></li>
             <li>
               <div class='menu-dropdown' aria-current='page'>Series
                 <ul class="main-menu menu-dropdown-content">
-                  <li><a href='http://us2ts.org/2019/' aria-current='page'>2019</a>
+                  <li><a href='/2019/' aria-current='page'>2019</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
-                  <li> <a href='http://us2ts.org/2018/' aria-current='page'>2018</a>
+                  <li> <a href='/2018/' aria-current='page'>2018</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
                 </ul>
@@ -112,7 +112,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/program.html'>Program</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/program.html'>Program</a>
                 </h3>
               </header>
             </article>
@@ -122,7 +122,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/registration.html'>Registration</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/registration.html'>Registration</a>
                 </h3>
               </header>
             </article>
@@ -133,7 +133,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/sponsor.html'>Sponsors</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/sponsor.html'>Sponsors</a> </h3>
               </header>
             </article>
 
@@ -143,7 +143,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/venue.html'>Venue</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/venue.html'>Venue</a> </h3>
               </header>
             </article>
 
@@ -154,7 +154,7 @@
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/cfp.html'>Call for Sessions Proposals</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/cfp.html'>Call for Sessions Proposals</a>
                 </h3>
               </header>
             </article>
@@ -167,7 +167,7 @@
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/committee.html'>Steering committee</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/committee.html'>Steering committee</a>
                 </h3>
               </header>
             </article>
@@ -178,7 +178,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2018' target="_blank">Past US2TS event</a> </h3>
+                <h3 class='list-item-title'> <a href='/2018' target="_blank">Past US2TS event</a> </h3>
               </header>
             </article>
           </div>

--- a/2019/posts/sponsor.html
+++ b/2019/posts/sponsor.html
@@ -15,16 +15,16 @@
   <title>2nd U.S. Semantic Technologies Symposium 2019</title>
 
   <link rel='canonical' href='http://us2ts.org/2019/'>
-  <link rel='icon' href='http://us2ts.org/2019/favicon.ico'>
+  <link rel='icon' href='/2019/favicon.ico'>
   <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-  <link rel='stylesheet' href="http://us2ts.org/2019/css/main.67a788c9.css">
-  <link rel='stylesheet' href="http://us2ts.org/2019/css/custom.css">
+  <link rel='stylesheet' href="/2019/css/main.67a788c9.css">
+  <link rel='stylesheet' href="/2019/css/custom.css">
 </head>
 
 <body class='home'>
   <div class='site'>
     <header id='header' class='header-container'>
-      <div><a href="http://us2ts.org"><img src="http://us2ts.org/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
+      <div><a href="/"><img src="/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
         U.S. Semantic Technologies Symposium Series <br />
         <div style="font-size: 70%;margin-left:120px;"> <b>March 11-13, 2019</b> at Duke University in Durham, NC</div>
       </div>
@@ -32,20 +32,20 @@
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
           <ul class='main-menu'>
-            <li><a href='http://us2ts.org/2019/' aria-current='page'>Home</a></li>
-            <li><a href='http://us2ts.org/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
-            <li><a href='http://us2ts.org/2019/posts/program.html' aria-current='page'>Program</a></li>
-            <li><a href='http://us2ts.org/2019/posts/registration.html' aria-current='page'>Registration</a></li>
-            <li><a href='http://us2ts.org/2019/posts/venue.html' aria-current='page'>Venue</a></li>
-            <li><a href='http://us2ts.org/2019/posts/sponsor.html' class='current' aria-current='page'>Sponsors</a></li>
-            <li><a href='http://us2ts.org/2019/posts/about.html' aria-current='page'>About</a></li>
+            <li><a href='/2019/' aria-current='page'>Home</a></li>
+            <li><a href='/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
+            <li><a href='/2019/posts/program.html' aria-current='page'>Program</a></li>
+            <li><a href='/2019/posts/registration.html' aria-current='page'>Registration</a></li>
+            <li><a href='/2019/posts/venue.html' aria-current='page'>Venue</a></li>
+            <li><a href='/2019/posts/sponsor.html' class='current' aria-current='page'>Sponsors</a></li>
+            <li><a href='/2019/posts/about.html' aria-current='page'>About</a></li>
             <li>
               <div class='menu-dropdown' aria-current='page'>Series
                 <ul class="main-menu menu-dropdown-content">
-                  <li><a href='http://us2ts.org/2019/' aria-current='page'>2019</a>
+                  <li><a href='/2019/' aria-current='page'>2019</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
-                  <li> <a href='http://us2ts.org/2018/' aria-current='page'>2018</a>
+                  <li> <a href='/2018/' aria-current='page'>2018</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
                 </ul>
@@ -90,38 +90,38 @@
               The following sponsors have expressed their financial support for US2TS 2019.
               <ul class="logo">
                 <li>
-                  <p><a href="https://nsf.gov/"> <img src="http://us2ts.org/2019/us2ts-sponsor-nsf.jpg" width="250px"></a>.</p>
+                  <p><a href="https://nsf.gov/"> <img src="/2019/us2ts-sponsor-nsf.jpg" width="250px"></a>.</p>
                 </li>
                 <li>
-                  <p><a href="https://sloan.org/"> <img src="http://us2ts.org/2019/us2ts-sponsor-alfred-sloan.svg"
+                  <p><a href="https://sloan.org/"> <img src="/2019/us2ts-sponsor-alfred-sloan.svg"
                         width="250px"></a>.</p>
                 </li>
                 <li>
-                  <p><a href="https://www.journals.elsevier.com/artificial-intelligence/"> <img src="http://us2ts.org/2019/us2ts-sponsor-aij.png"
+                  <p><a href="https://www.journals.elsevier.com/artificial-intelligence/"> <img src="/2019/us2ts-sponsor-aij.png"
                         width="250px"></a>.</p>
                 </li>
               </ul>
               <p><b>Platinum Sponsors</b></p>
               <ul class="logo">
                 <li>
-                  <p><a href="https://www.ge.com/research/technology-domains/artificial-intelligence/knowledge-management-big-data"> <img src="http://us2ts.org/2019/us2ts-sponsor-ge.png"
+                  <p><a href="https://www.ge.com/research/technology-domains/artificial-intelligence/knowledge-management-big-data"> <img src="/2019/us2ts-sponsor-ge.png"
                         width="250px"></a>.</p>
                 </li>
 
 			  <li>
-                  <p><a href="https://mobi.inovexcorp.com/"> <img src="http://us2ts.org/2019/us2ts-sponsor-mobi-powered-by-inovex-primary.png"
+                  <p><a href="https://mobi.inovexcorp.com/"> <img src="/2019/us2ts-sponsor-mobi-powered-by-inovex-primary.png"
                         width="250px"></a>.</p>
                 </li>
                 <li>
-                  <p><a href="https://www.raytheon.com/ourcompany/bbn"> <img src="http://us2ts.org/2019/us2ts-sponsor-bbn.png"
+                  <p><a href="https://www.raytheon.com/ourcompany/bbn"> <img src="/2019/us2ts-sponsor-bbn.png"
                         width="250px"></a>.</p>
                 </li>
 				<li>
-                  <p><a href="https://data.world/"> <img src="http://us2ts.org/2019/us2ts-sponsor-data.world.png"
+                  <p><a href="https://data.world/"> <img src="/2019/us2ts-sponsor-data.world.png"
                         width="250px"></a>.</p>
                 </li>
                 <li>
-                  <p><a href="https://tenet3.com/"> <img src="http://us2ts.org/2019/us2ts-sponsor-tenet3.png"
+                  <p><a href="https://tenet3.com/"> <img src="/2019/us2ts-sponsor-tenet3.png"
                         width="250px"></a>.</p>
                 </li>                
                 
@@ -131,11 +131,11 @@
               <ul class="logo">
                 
                 <li>
-                  <p><a href="http://www.bosch.com/research"> <img src="http://us2ts.org/2019/us2ts-sponsor-bosch-2019.jpg"
+                  <p><a href="http://www.bosch.com/research"> <img src="/2019/us2ts-sponsor-bosch-2019.jpg"
                         width="250px"></a>.</p>
                 </li>
                 <li>
-                  <p><a href="https://www.iospress.nl/subject/semantic-web/"> <img src="http://us2ts.org/2019/us2ts-sponsor-ios.jpg"
+                  <p><a href="https://www.iospress.nl/subject/semantic-web/"> <img src="/2019/us2ts-sponsor-ios.jpg"
                         width="250px"></a>.</p>
                 </li>
               </ul>
@@ -154,7 +154,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/program.html'>Program</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/program.html'>Program</a>
                 </h3>
               </header>
             </article>
@@ -164,7 +164,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/registration.html'>Registration</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/registration.html'>Registration</a>
                 </h3>
               </header>
             </article>
@@ -175,7 +175,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/sponsor.html'>Sponsors</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/sponsor.html'>Sponsors</a> </h3>
               </header>
             </article>
 
@@ -185,7 +185,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/venue.html'>Venue</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/venue.html'>Venue</a> </h3>
               </header>
             </article>
 
@@ -196,7 +196,7 @@
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/cfp.html'>Call for Sessions Proposals</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/cfp.html'>Call for Sessions Proposals</a>
                 </h3>
               </header>
             </article>
@@ -209,7 +209,7 @@
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/committee.html'>Steering committee</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/committee.html'>Steering committee</a>
                 </h3>
               </header>
             </article>
@@ -220,7 +220,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2018' target="_blank">Past US2TS event</a> </h3>
+                <h3 class='list-item-title'> <a href='/2018' target="_blank">Past US2TS event</a> </h3>
               </header>
             </article>
           </div>

--- a/2019/posts/venue.html
+++ b/2019/posts/venue.html
@@ -15,16 +15,16 @@
     <title>2nd U.S. Semantic Technologies Symposium 2019</title>
   
     <link rel='canonical' href='http://us2ts.org/2019/'>
-    <link rel='icon' href='http://us2ts.org/2019/favicon.ico'>
+    <link rel='icon' href='/2019/favicon.ico'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/main.67a788c9.css">
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/custom.css">
+    <link rel='stylesheet' href="/2019/css/main.67a788c9.css">
+    <link rel='stylesheet' href="/2019/css/custom.css">
   </head>
   
 <body class='home'>
   <div class='site'>
     <header id='header' class='header-container'>
-      <div><a href="http://us2ts.org"><img src="http://us2ts.org/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
+      <div><a href="/"><img src="/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
         U.S. Semantic Technologies Symposium Series <br />
         <div style="font-size: 70%;margin-left:120px;"> <b>March 11-13, 2019</b> at Duke University in Durham, NC</div>
       </div>
@@ -32,20 +32,20 @@
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
           <ul class='main-menu'>
-            <li><a href='http://us2ts.org/2019/' aria-current='page'>Home</a></li>
-            <li><a href='http://us2ts.org/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
-            <li><a href='http://us2ts.org/2019/posts/program.html' aria-current='page'>Program</a></li>
-            <li><a href='http://us2ts.org/2019/posts/registration.html' aria-current='page'>Registration</a></li>
-            <li><a href='http://us2ts.org/2019/posts/venue.html' class='current' aria-current='page'>Venue</a></li>
-            <li><a href='http://us2ts.org/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
-            <li><a href='http://us2ts.org/2019/posts/about.html' aria-current='page'>About</a></li>
+            <li><a href='/2019/' aria-current='page'>Home</a></li>
+            <li><a href='/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
+            <li><a href='/2019/posts/program.html' aria-current='page'>Program</a></li>
+            <li><a href='/2019/posts/registration.html' aria-current='page'>Registration</a></li>
+            <li><a href='/2019/posts/venue.html' class='current' aria-current='page'>Venue</a></li>
+            <li><a href='/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
+            <li><a href='/2019/posts/about.html' aria-current='page'>About</a></li>
             <li>
               <div class='menu-dropdown' aria-current='page'>Series
                 <ul class="main-menu menu-dropdown-content">
-                  <li><a href='http://us2ts.org/2019/' aria-current='page'>2019</a>
+                  <li><a href='/2019/' aria-current='page'>2019</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
-                  <li> <a href='http://us2ts.org/2018/' aria-current='page'>2018</a>
+                  <li> <a href='/2018/' aria-current='page'>2018</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
                 </ul>
@@ -126,7 +126,7 @@ If you plan to drive to Durham, note that parking on Duke campus is perennially 
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/program.html'>Program</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/program.html'>Program</a>
                 </h3>
               </header>
             </article>
@@ -136,7 +136,7 @@ If you plan to drive to Durham, note that parking on Duke campus is perennially 
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/registration.html'>Registration</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/registration.html'>Registration</a>
                 </h3>
               </header>
             </article>
@@ -147,7 +147,7 @@ If you plan to drive to Durham, note that parking on Duke campus is perennially 
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/sponsor.html'>Sponsors</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/sponsor.html'>Sponsors</a> </h3>
               </header>
             </article>
 
@@ -157,7 +157,7 @@ If you plan to drive to Durham, note that parking on Duke campus is perennially 
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/venue.html'>Venue</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/venue.html'>Venue</a> </h3>
               </header>
             </article>
 
@@ -168,7 +168,7 @@ If you plan to drive to Durham, note that parking on Duke campus is perennially 
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/cfp.html'>Call for Sessions Proposals</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/cfp.html'>Call for Sessions Proposals</a>
                 </h3>
               </header>
             </article>
@@ -181,7 +181,7 @@ If you plan to drive to Durham, note that parking on Duke campus is perennially 
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/committee.html'>Steering committee</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/committee.html'>Steering committee</a>
                 </h3>
               </header>
             </article>
@@ -192,7 +192,7 @@ If you plan to drive to Durham, note that parking on Duke campus is perennially 
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2018' target="_blank">Past US2TS event</a> </h3>
+                <h3 class='list-item-title'> <a href='/2018' target="_blank">Past US2TS event</a> </h3>
               </header>
             </article>
           </div>

--- a/index.html
+++ b/index.html
@@ -13,16 +13,16 @@
     <meta property='og:type' content='website'>
     <meta property='og:updated_time' content='2019-02-27' />
   
-    <link rel='icon' href='http://us2ts.org/2019/favicon.ico'>
+    <link rel='icon' href='/2019/favicon.ico'>
     <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/main.67a788c9.css">
-    <link rel='stylesheet' href="http://us2ts.org/2019/css/custom.css">
+    <link rel='stylesheet' href="/2019/css/main.67a788c9.css">
+    <link rel='stylesheet' href="/2019/css/custom.css">
   </head>
   
 <body class='home'>
   <div class='site'>
     <header id='header' class='header-container'>
-      <div><a href="http://us2ts.org"><img src="http://us2ts.org/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
+      <div><a href="/"><img src="/us2ts_color.png" width="100pt" alt="U.S. Semantic Technologies Symposium"></a>
         U.S. Semantic Technologies Symposium Series <br />
         <div style="font-size: 70%;margin-left:120px;"> <b>March 11-13, 2019</b> at Duke University in Durham, NC</div>
       </div>
@@ -30,20 +30,20 @@
       <div class='site-header'>
         <nav id='navmenu' aria-label='Main Menu'>
           <ul class='main-menu'>
-            <li><a href='http://us2ts.org/2019/' class='current' aria-current='page'>Home</a></li>
-            <li><a href='http://us2ts.org/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
-            <li><a href='http://us2ts.org/2019/posts/program.html' aria-current='page'>Program</a></li>
-            <li><a href='http://us2ts.org/2019/posts/registration.html' aria-current='page'>Registration</a></li>            
-            <li><a href='http://us2ts.org/2019/posts/venue.html' aria-current='page'>Venue</a></li>            
-            <li><a href='http://us2ts.org/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
-            <li><a href='http://us2ts.org/2019/posts/about.html'  aria-current='page'>About</a></li>
+            <li><a href='/2019/' class='current' aria-current='page'>Home</a></li>
+            <li><a href='/2019/posts/cfp.html' aria-current='page'>Calls</a></li>
+            <li><a href='/2019/posts/program.html' aria-current='page'>Program</a></li>
+            <li><a href='/2019/posts/registration.html' aria-current='page'>Registration</a></li>            
+            <li><a href='/2019/posts/venue.html' aria-current='page'>Venue</a></li>            
+            <li><a href='/2019/posts/sponsor.html' aria-current='page'>Sponsors</a></li>
+            <li><a href='/2019/posts/about.html'  aria-current='page'>About</a></li>
             <li>
               <div class='menu-dropdown' aria-current='page'>Series
                 <ul class="main-menu menu-dropdown-content">
-                  <li><a href='http://us2ts.org/2019/' aria-current='page'>2019</a>
+                  <li><a href='/2019/' aria-current='page'>2019</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
-                  <li> <a href='http://us2ts.org/2018/' aria-current='page'>2018</a>
+                  <li> <a href='/2018/' aria-current='page'>2018</a>
                     <hr style="height:1px;max-height:1px; margin:1px;padding:0px;" />
                   </li>
                 </ul>
@@ -70,8 +70,8 @@
 		  
         <p><strong>News:</strong> <a href="https://tw.rpi.edu/web/person/deborah_l_mcguinness"> Deborah McGuinness</a> will be our opening keynote speaker.</p>
         
-        <p><strong>News:</strong> <a href="http://us2ts.org/2019/posts/cfp.html" target="_blank"> Call for Posters </a>. Deadline: Feb 25, 2019 (first-come first-serve) </p>
-        <p><strong>News:</strong> <a href="http://us2ts.org/2019/posts/cfp.html" target="_blank">Call for Lightning Talks </a>. Deadline: Open until slots filled (first-come first-serve) </p>
+        <p><strong>News:</strong> <a href="/2019/posts/cfp.html" target="_blank"> Call for Posters </a>. Deadline: Feb 25, 2019 (first-come first-serve) </p>
+        <p><strong>News:</strong> <a href="/2019/posts/cfp.html" target="_blank">Call for Lightning Talks </a>. Deadline: Open until slots filled (first-come first-serve) </p>
         <p><strong>News:</strong> <a href="https://www.linkedin.com/in/helenadeus/" target="_blank">Helena Deus </a>, Technology Research Director at Elsevier will give a keynote. </p>
 	<p><strong>News:</strong> 	  The Open Bioinformatics Foundation (OBF) offers a Travel Fellowship program, with a particular focus on increasing diversity at bioinformatics-related events by helping to lower financial barriers to participation. This includes the US2TS conference. Travel awards are up to $1,000, and applications are reviewed three times a year, with the next deadline on Saturday, December 15, 2018. More information, including how to apply, can be found at <a href="https://github.com/OBF/obf-docs/blob/master/Travel_fellowships.md" target="_blank">https://github.com/OBF/obf-docs/blob/master/Travel_fellowships.md</a>
 	</p>
@@ -79,10 +79,10 @@
 	<p><strong>News:</strong> Registration now available through RegOnline. Please <a href='https://www.regonline.com/builder/site/Default.aspx?EventID=2549049&'
           target="_blank">click here</a> for registration.</p>   
       <p><strong>News:</strong> Students and early-career professionals can apply for Travel grant funded by the Alfred P.
-        Sloan Foundation and the US National Science Foundation (NSF). Please <a href='http://www.us2ts.org/2019/us2ts2019-student.pdf'
+        Sloan Foundation and the US National Science Foundation (NSF). Please <a href='/2019/us2ts2019-student.pdf'
           target="_blank">click here</a> for more details. Application Deadline: December 23, 2018 </p>
      
-      <p><strong>News:</strong> Call for Sessions Proposals. <a href='http://us2ts.org/2019/posts/cfp.html'> Click here </a>
+      <p><strong>News:</strong> Call for Sessions Proposals. <a href='/2019/posts/cfp.html'> Click here </a>
         for details. Deadline for submissions: October 31, 2018</p>
       <p><strong>News:</strong> Join our mailing list <a href="https://groups.google.com/forum/#!forum/us2ts">here</a> to
         be kept informed. </p>
@@ -123,7 +123,7 @@
         <li>Krzysztof Janowicz (Outgoing Program Chair)</li>
       </ul>
       <p>For all questions please contact the organizers at <a href="mailto:contact-us2ts2019@googlegroups.com">contact-us2ts2019@googlegroups.com</a></p>
-      <p> Past Event: <a href='http://us2ts.org/2018' target="_blank"> US2TS 2018</a> </p>
+      <p> Past Event: <a href='/2018' target="_blank"> US2TS 2018</a> </p>
     </div>
   </article>
   </main>
@@ -139,7 +139,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/program.html'>Program</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/program.html'>Program</a>
                 </h3>
               </header>
             </article>
@@ -149,7 +149,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/registration.html'>Registration</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/registration.html'>Registration</a>
                 </h3>
               </header>
             </article>
@@ -160,7 +160,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/sponsor.html'>Sponsors</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/sponsor.html'>Sponsors</a> </h3>
               </header>
             </article>
 
@@ -170,7 +170,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/venue.html'>Venue</a> </h3>
+                <h3 class='list-item-title'> <a href='/2019/posts/venue.html'>Venue</a> </h3>
               </header>
             </article>
 
@@ -181,7 +181,7 @@
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/cfp.html'>Call for Sessions Proposals</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/cfp.html'>Call for Sessions Proposals</a>
                 </h3>
               </header>
             </article>
@@ -194,7 +194,7 @@
 
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2019/posts/committee.html'>Steering committee</a>
+                <h3 class='list-item-title'> <a href='/2019/posts/committee.html'>Steering committee</a>
                 </h3>
               </header>
             </article>
@@ -205,7 +205,7 @@
                 </span>
               </div>
               <header class='list-item-header'>
-                <h3 class='list-item-title'> <a href='http://us2ts.org/2018' target="_blank">Past US2TS event</a> </h3>
+                <h3 class='list-item-title'> <a href='/2018' target="_blank">Past US2TS event</a> </h3>
               </header>
             </article>
           </div>


### PR DESCRIPTION
This doesn't hardcode CSS, JS, and backlinks to http or https, and doesn't hardcode the domain name either, making it much easier to maintain on different hosting platforms (including Github Pages). Also makes it possible to test the site locally.