### PR TITLE
Creates sponsorship packages documentation

### DIFF
--- a/pages/sponsorpkg.md
+++ b/pages/sponsorpkg.md
@@ -1,0 +1,41 @@
+---
+layout: page
+title: US2TS Sponsor Packages
+sidebartitle: Sponsor Packages
+author: Hilmar Lapp
+permalink: sponsor_packages
+mainnav: false
+published: true
+order: 6
+---
+
+US2TS would not be possible without the generous support of sponsors. We offer the following standard tiers for sponsorship. Special arrangements, whether within or outside one of these tiers, are possible if a sponsor’s needs are not well covered by any of the tiers. If you are interested in sponsoring but require a special arrangement please email contact@us2ts.org. 
+
+### Standard Tier
+
+* logo on website listed as sponsor
+* logo on all event promotions
+* inclusion of flyer (if provided) in conference pack
+
+**Requested amnount: $1,000**
+
+### Platinum Tier
+
+* logo on website, listed as platinum sponsor
+* logo on all event promotions
+* inclusion of flyer (if provided) in conference pack
+* table (and chair if desired) for demonstration or display
+* one free registration
+
+**Requested amount: $1500** (availability as permitted by space for demonstration tables)
+
+### Special Event Sponsor
+
+* logo on website, listed as social event sponsor
+* acknowledgement on website and all event promotions as social event sponsor
+* inclusion of flyer (if provided) in conference pack
+* special mention at opening session and at the social event
+* table (and chair if desired) for demonstration or display
+* one free registration
+
+**Requested amount: $2,000** (limited availability)

--- a/pages/sponsorpkg.md
+++ b/pages/sponsorpkg.md
@@ -27,7 +27,7 @@ US2TS would not be possible without the generous support of sponsors. We offer t
 * table (and chair if desired) for demonstration or display
 * one free registration
 
-**Requested amount: $1500** (availability as permitted by space for demonstration tables)
+**Requested amount: $1,500** (availability as permitted by space for demonstration tables)
 
 ### Special Event Sponsor
 


### PR DESCRIPTION
@maulikkamdar I think I set the metadata right to keep it out of the list of tabs (but can you please double check). Given that the great majority of visitors to the site will _not_ be prospective sponsors, I don't think it needs to be in the sidebar either, but don't know how to disable that. If it can't be easily disabled, that's fine though – there's nothing here that's needs to be hidden.