### PR TITLE
Removes 'click here' instances where unnecessary

### DIFF
--- a/pages/registration.md
+++ b/pages/registration.md
@@ -18,6 +18,6 @@ Registration is now open through the [US2TS 2020 registration website](https://c
 
 Poster display space is free of charge at least until the end of Early Registration, but limited and allocated first-come first-serve. If you intend to present a poster, please indicate so as part of your registration.
 
-We are trying hard to keep costs of attendance low and affordable. If you require travel support to attend, a limited amount of travel support grants are available for students and early-career professionals. Please [**click here**](https://us2ts.org/travel-awards) for more information on how to apply for the travel award.
+We are trying hard to keep costs of attendance low and affordable. If you require travel support to attend, a limited amount of [travel support grants are available](https://us2ts.org/travel-awards) for students and early-career professionals (note: deadline for applying is Feb 4).
 
-[Click here](https://us2ts.org/venue) for more information on the venue and accommodation.
+Information about accommodation can be found under the [venue information](https://us2ts.org/venue).


### PR DESCRIPTION
Hyperlinks are already made for "clicking here", so most of the time saying "Click here" is simply redundant.